### PR TITLE
기기간 근거리 P2P 연결 통신 Framework 구현

### DIFF
--- a/iOS/Sources/ContentView.swift
+++ b/iOS/Sources/ContentView.swift
@@ -5,33 +5,85 @@ struct ContentView: View {
     // 1. AR 데이터 매니저
     @State var faceManager = FaceTrackingManager()
 
-    // 2. 게임 씬 생성
+    // 2. 네트워크 매니저
+    @State var p2pManager = P2PManager()
+    // 중복 전송 방지용 플래그
+    @State private var isJumpSent = false
+    // 3. 게임 씬
     @State var gameScene: CosmicGameScene = {
         let scene = CosmicGameScene(size: UIScreen.main.bounds.size)
         scene.scaleMode = .aspectFill
         scene.backgroundColor = .clear
-        // 앵커 포인트를 중앙으로 설정
         scene.anchorPoint = CGPoint(x: 0.5, y: 0.5)
-
         return scene
     }()
 
     var body: some View {
+        Group {
+            if p2pManager.isConnected {
+                // [게임 화면] 연결되면 게임 시작
+                gameView
+            } else {
+                // [대기 화면] 주변 유저 목록 표시
+                lobbyView
+            }
+        }
+        // 상대방 신호 수신
+        .onChange(of: p2pManager.receivedAction) {
+            if p2pManager.receivedAction == "jump" {
+                print("상대방 점프 신호 받음!")
+                // 여기에 상대방 캐릭터 점프 로직 추가 가능
+            }
+        }
+    }
+
+    // 대기 화면 (Lobby)
+    var lobbyView: some View {
+        NavigationView {
+            VStack {
+                Text("내 기기 이름: \(p2pManager.myName)")
+                    .font(.headline)
+                    .padding()
+                    .background(Color.yellow.opacity(0.2))
+                    .cornerRadius(8)
+                    .padding(.top, 10)
+
+                List(p2pManager.availablePeers) { peer in
+                    Button {
+                        p2pManager.connectTo(peer: peer) // 터치하면 연결 시도
+                    } label: {
+                        HStack {
+                            Image(systemName: "iphone")
+                            Text(peer.name)
+                            Spacer()
+                            Text("대결하기")
+                                .foregroundColor(.blue)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("상대 찾는 중...")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    ProgressView()
+                }
+            }
+        }
+    }
+
+    // 게임 화면
+    var gameView: some View {
         ZStack {
-            // 레이어 1: AR 세션
             ARViewContainer(session: faceManager.session)
                 .ignoresSafeArea()
 
-            // 레이어 2: 게임 화면 (SpriteView)
             SpriteView(scene: gameScene, options: [.allowsTransparency])
                 .ignoresSafeArea()
                 .background(Color.clear)
 
-            // 레이어 3: 디버그 정보
             VStack {
                 HStack {
                     Text("우~: \(String(format: "%.2f", faceManager.mouthPuckerValue))")
-                    Text("볼빵빵: \(String(format: "%.2f", faceManager.cheekPuffValue))")
                 }
                 .foregroundColor(.white)
                 .padding()
@@ -41,31 +93,28 @@ struct ContentView: View {
             }
             .padding(.top, 50)
         }
-        // 데이터가 변할 때마다 게임 씬에 알려줌
-        .onChange(of: faceManager.cheekPuffValue) {
-            updateGameInput()
-        }
+        // 내 행동 -> 네트워크 전송
         .onChange(of: faceManager.mouthPuckerValue) {
-            updateGameInput()
-        }
-        .onChange(of: faceManager.headRoll) {
-            updateGameInput()
-        }
-    }
+            gameScene.updateInput(
+                pucker: faceManager.mouthPuckerValue,
+                puff: faceManager.cheekPuffValue,
+                jawOpen: faceManager.jawOpenValue,
+                roll: faceManager.headRoll
+            )
 
-    // 입력을 게임 씬으로 전달하는 헬퍼 함수
-    private func updateGameInput() {
-        gameScene.updateInput(
-            pucker: faceManager.mouthPuckerValue,
-            puff: faceManager.cheekPuffValue,
-            jawOpen: faceManager.jawOpenValue,
-            roll: faceManager.headRoll
-        )
-    }
-}
-
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
+            // "우~" 해서 점프하면 상대에게도 전송
+            // 임계값(0.3)을 넘었고, 아직 전송 안 한 상태일 때만 보냄
+            if faceManager.mouthPuckerValue > 0.3 {
+                if !isJumpSent {
+                    p2pManager.send(action: "jump")
+                    isJumpSent = true // "보냈음"으로 상태 변경 (잠금)
+                    print("점프 신호 1회 전송")
+                }
+            }
+            // 입을 풀어서(0.2 미만) 다시 돌아오면 잠금 해제
+            else if faceManager.mouthPuckerValue < 0.2 {
+                isJumpSent = false
+            }
+        }
     }
 }

--- a/iOS/Sources/P2PManager.swift
+++ b/iOS/Sources/P2PManager.swift
@@ -1,0 +1,205 @@
+//
+//  P2PManager.swift
+//  iOS
+//
+//  Created by soyoung on 12/17/25.
+//
+
+import Network
+import Observation
+import UIKit
+
+// 발견된 유저 모델
+struct Peer: Identifiable, Hashable {
+    // UUID()를 매번 생성하지 않고, endpoint 자체를 식별자로 사용해야 리스트가 안정됨
+    var id: String { endpoint.debugDescription }
+    let endpoint: NWEndpoint
+
+    var name: String {
+        if case let .service(name, _, _, _) = endpoint {
+            return name
+        }
+        return "Unknown User"
+    }
+}
+
+@Observable
+class P2PManager {
+    // 설정
+    private let serviceType = "_cosmicgame._tcp"
+    var myName: String = {
+        let deviceName = UIDevice.current.name
+        let randomId = Int.random(in: 10...99)
+        return "\(deviceName)-\(randomId)"
+    }()
+
+    private var listener: NWListener?
+    private var browser: NWBrowser?
+    private var connection: NWConnection?
+
+    var availablePeers: [Peer] = []
+    var isConnected: Bool = false
+    var receivedAction: String = ""
+
+    init() {
+        print("P2PManager 초기화: 내 이름 [\(myName)]")
+        startAdvertising()
+        startBrowsing()
+    }
+
+    // MARK: - 1. 대기실 (Advertising & Browsing)
+    private func startAdvertising() {
+        do {
+            let parameters = NWParameters.tcp
+            listener = try NWListener(using: parameters)
+            listener?.service = NWListener.Service(name: myName, type: serviceType)
+
+            listener?.newConnectionHandler = { [weak self] newConnection in
+                print("[Listener] 누군가 나에게 연결 시도! (Endpoint: \(newConnection.endpoint))")
+                self?.acceptConnection(newConnection)
+            }
+
+            listener?.stateUpdateHandler = { state in
+                switch state {
+                case .ready: print("[Listener] 방송 시작 (내 기기 검색 가능)")
+                case .failed(let error): print("[Listener] 방송 실패: \(error)")
+                case .cancelled: print("[Listener] 방송 중지됨")
+                default: break
+                }
+            }
+            listener?.start(queue: .main)
+        } catch {
+            print("[Listener] 생성 에러: \(error)")
+        }
+    }
+
+    private func startBrowsing() {
+        let parameters = NWParameters()
+        parameters.includePeerToPeer = true
+        let descriptor = NWBrowser.Descriptor.bonjour(type: serviceType, domain: nil)
+
+        browser = NWBrowser(for: descriptor, using: parameters)
+
+        browser?.browseResultsChangedHandler = { [weak self] results, changes in
+            // 검색 결과가 바뀔 때마다 로그 출력
+            print("[Browser] 발견된 기기 수: \(results.count)명")
+
+            let peers = results.map { Peer(endpoint: $0.endpoint) }
+
+            // UI 업데이트는 메인 스레드 보장
+            DispatchQueue.main.async {
+                self?.availablePeers = peers
+            }
+        }
+
+        browser?.start(queue: .main)
+    }
+
+    // MARK: - 2. 연결 로직 (핵심 디버깅 구간)
+
+    // [CASE A] 내가 버튼을 눌러서 연결 요청
+    func connectTo(peer: Peer) {
+        print("[Connect] '\(peer.name)'에게 연결 요청 시작...")
+
+        connection?.cancel() // 기존 연결 정리
+
+        let newConnection = NWConnection(to: peer.endpoint, using: .tcp)
+        self.connection = newConnection
+
+        setupConnection(newConnection, isInitiator: true)
+        newConnection.start(queue: .main)
+    }
+
+    // [CASE B] 상대가 나에게 연결해와서 수락
+    private func acceptConnection(_ newConnection: NWConnection) {
+        print("[Accept] 상대방 연결 수락 중...")
+
+        connection?.cancel()
+        self.connection = newConnection
+
+        setupConnection(newConnection, isInitiator: false)
+        newConnection.start(queue: .main)
+    }
+
+    // 공통 연결 설정
+    private func setupConnection(_ conn: NWConnection, isInitiator: Bool) {
+        conn.stateUpdateHandler = { [weak self] state in
+            let role = isInitiator ? "[발신자]" : "[수신자]"
+
+            switch state {
+            case .preparing:
+                print("\(role) 연결 준비 중...")
+            case .ready:
+                print("\(role) 연결 성공! (State: Ready)")
+
+                // 화면 전환 트리거 (반드시 메인 스레드)
+                DispatchQueue.main.async {
+                    self?.isConnected = true
+                    self?.stopDiscovery() // 연결되면 탐색/방송 중지
+                    print("[UI] isConnected = true 변경 완료")
+                }
+                self?.receiveData()
+
+            case .failed(let error):
+                print("\(role) 연결 실패: \(error)")
+                DispatchQueue.main.async { self?.isConnected = false }
+
+            case .cancelled:
+                print("\(role) 연결 취소됨")
+                DispatchQueue.main.async { self?.isConnected = false }
+
+            case .waiting(let error):
+                print("\(role) 연결 대기 중 (재시도 예정): \(error)")
+
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    // MARK: - 3. 데이터 송수신
+    private func receiveData() {
+        connection?.receive(minimumIncompleteLength: 1, maximumLength: 1024) { [weak self] data, _, isComplete, error in
+            if let data = data, let message = String(data: data, encoding: .utf8) {
+                // 줄바꿈 기준으로 쪼개서 처리 (jumpjump 문제 해결)
+                let commands = message.split(separator: "\n")
+                for command in commands {
+                    let cleanAction = String(command)
+                    print("[Data] 수신: \(cleanAction)")
+
+                    DispatchQueue.main.async {
+                        self?.receivedAction = cleanAction
+                    }
+                }
+            }
+
+            if isComplete {
+                print("[Connection] 상대방이 연결을 끊음")
+                DispatchQueue.main.async { self?.isConnected = false }
+            } else if let error = error {
+                print("[Connection] 수신 에러: \(error)")
+            } else {
+                self?.receiveData() // 계속 수신 대기
+            }
+        }
+    }
+
+    func send(action: String) {
+        let messageToSend = action + "\n"
+        guard let data = messageToSend.data(using: .utf8) else { return }
+
+        connection?.send(content: data, completion: .contentProcessed({ error in
+            if let error = error {
+                print("[Send] 전송 실패: \(error)")
+            } else {
+                // print("[Send] 전송 성공: \(action)") // 너무 시끄러우면 주석 처리
+            }
+        }))
+    }
+
+    private func stopDiscovery() {
+        print("[System] 연결 성사로 인해 탐색 및 방송 중지")
+        browser?.cancel()
+        listener?.cancel()
+    }
+}


### PR DESCRIPTION
[DEV-8]

## 요약
- Network.framework를 활용하여 Host(Advertising)/Guest(Browsing) 간 P2P 연결 프로세스를 정립하고, 랜덤 ID 를 통해 연결 기기를 식별할 수 있도록 했습니다.
<br/>

## **작업목록**
- [x]  P2P 아키텍처 구현: NWListener(방장/Advertising)와 NWBrowser(참여자/Browsing)를 활용한 역할 분리 및 연결 로직 구축
- [x]  기기 식별 이슈 해결: iOS Privacy 정책에 대응하여 고유 식별을 위한 '랜덤 ID(예: iPhone-42)' 생성 로직 적용
<br/>

## 작업 내용
### 1. 기기간 근거리 P2P 연결 통신 구현

`Network.framework` 로 로컬 네트워크상에서 기기 간 직접 연결을 구현했습니다. 

**Host(방장)** 와 **Guest(참여자)** 의 역할 분리를 통해 서비스 탐색 및 연결 프로세스를 정립했습니다.

- **Host (방장) - Advertising**
    - **역할:** `NWListener`를 사용하여 로컬 네트워크에 자신의 존재를 알립니다.
    - **구현:** 지정된 Bonjour Service 문자열(`_cosmicgame._tcp`)을 사용하여 *"나 여기 있어, 연결 가능해!"* 라는 신호를 지속적으로 방송(Advertising)합니다.
    - **연결 대기:** Guest의 연결 요청이 들어오면 `listener.newConnectionHandler`를 통해 수락하고 세션을 생성합니다.
- **Guest (참여자) - Browsing**
    - **역할:** `NWBrowser`를 사용하여 주변에 활성화된 Host를 탐색합니다.
    - **구현:** `_cosmicgame._tcp` 서비스를 방송 중인 기기를 실시간으로 스캔(Browsing)합니다.
    - **연결 요청:** 검색된 피어(Peer) 목록을 UI에 표시하고, 사용자가 특정 기기를 선택하면 해당 Endpoint로 `NWConnection`을 생성하여 1:1 TCP 연결을 요청합니다.
<br/>

### 2. 기기 식별 이슈 및 해결

iOS의 개인정보 보호 정책 강화로 인한 기기 이름 식별 불가 문제를 해결했습니다.

- **문제 상황:**
    - iOS 16 이상부터 앱이 적절한 권한(Entitlement) 없이 `UIDevice.current.name`에 접근할 경우, 사용자가 설정한 실제 이름(예: "00의 아이폰") 대신 기기 모델명(예: "iPhone")만 반환됩니다.
    - 이로 인해 다수의 기기가 모두 `iPhone`, `iPhone(2)`로 표시되어 사용자가 상대방을 특정할 수 없는 문제가 발생했습니다.
- **해결 방안:**
    - **랜덤 ID 부여:** 앱 실행 시 `[모델명]-[랜덤 숫자]` 형식의 고유 식별자(예: `iPhone-42`)를 생성하여 할당했습니다.
    - **결과:** 별도의 민감한 권한 요청 없이도, 리스트에서 `iPhone-42`, `iPhone-88`과 같이 상대를 명확히 구분하고 연결할 수 있도록 하였습니다.
    - 실제 구현에서는 닉네임으로 구현하면 될 것 같습니다.
  <br/>

### UI 변경
[Host]

https://github.com/user-attachments/assets/f97a13f5-84cc-46ba-adc6-653a770e131e

<br/>

[Guest]

https://github.com/user-attachments/assets/6fd3fa57-a136-4470-9071-4855bfef73e9

<br/>

refs DEV-8
