### PR TITLE
[DEV-36] Tuist iOS 최소 버전 및 developmentTeam 기본 설정

### DIFF
--- a/iOS/App/Project.swift
+++ b/iOS/App/Project.swift
@@ -46,7 +46,13 @@ let project = Project(
                 .project(target: "InputSystem", path: "../Modules/InputSystem"),
                 .project(target: "GameEngineCore", path: "../Modules/GameEngineCore"),
                 .project(target: "NetworkKit", path: "../Modules/NetworkKit"),
-            ]
+            ],
+            settings: .settings(
+                base: [
+                    "DEVELOPMENT_TEAM": "B3PWYBKFUK",
+                    "CODE_SIGN_STYLE": "Automatic",
+                ]
+            )
         ),
         Target.target(
             name: "AppTests",


### PR DESCRIPTION
## 요약
- iOS minimum deployment target이 18.0으로 설정되게 변경
- developmentTeam의 기본값 설정

### 작업 목록

- [x] iOS minimum deployment target이 18.0으로 설정되게 변경
- [x] developmentTeam의 기본값 설정(tuist generate시 초기화되지 않도록)

## 작업 내용
테스트 타겟과 버전 불일치로 빌드에 번거로움이 있어 최소 버전 설정해두었습니다.
tuist generate 시 developmentTeam이 초기화되어 기본값을 설정했습니다.

closes/refs DEV-36
