### PR TITLE
[DEV-51] 프로필 화면 키보드 포커싱 개선

### DIFF
--- a/iOS/App/Sources/Presentation/ProfileSetup/ProfileSetupView.swift
+++ b/iOS/App/Sources/Presentation/ProfileSetup/ProfileSetupView.swift
@@ -11,6 +11,7 @@ struct ProfileSetupView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(AppRouter.self) private var router: AppRouter
     @State private var viewModel: ProfileSetupViewModel
+    @FocusState private var isNicknameFocused: Bool
 
     init(viewModel: ProfileSetupViewModel) {
         _viewModel = State(initialValue: viewModel)
@@ -49,6 +50,10 @@ struct ProfileSetupView: View {
                 .padding(.horizontal, 20)
                 .padding(.bottom, 70)
             }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            isNicknameFocused = false
         }
     }
 }
@@ -100,6 +105,7 @@ private extension ProfileSetupView {
                 prompt: Text(Constants.ProfileSetup.nicknamePlaceholder)
                     .foregroundStyle(AppAsset.Color.subBlackLabel.swiftUIColor)
             )
+            .focused($isNicknameFocused)
             .font(AppFontFamily.Pretendard.regular.swiftUIFont(size: 16))
             .foregroundStyle(AppAsset.Color.blackLabel.swiftUIColor)
             .padding(.vertical, 16)


### PR DESCRIPTION
## 요약
- 프로필 화면 키보드 포커싱을 개선하였습니다.

### 작업 목록
- [X] 프로필 뷰 빈 공간 터치 시 키보드 내려가도록 변경

## 작업 내용
### AS-IS
프로필 뷰 빈 공간 터치 시 키보드 내려가지 않음

### TO-BE
### 프로필 화면 키보드 포커싱 개선
- 배경 터치 시 키보드 숨김 처리: 프로필 뷰의 빈 공간을 터치하면 키보드가 내려가도록 UX 개선
- @FocusState 적용: 닉네임 입력 필드의 포커스 상태 관리
- 터치 영역 확장: BackgroundContainerView에 .contentShape(Rectangle())를 적용해 터치 인식 영역을 확장.
- .onTapGesture를 통해 포커스 상태를 false로 전환하여 키보드 숨김 로직 구현

### UI 변경 
https://github.com/user-attachments/assets/51175f4c-55ee-49b3-bb77-aecf8fb7b9a3

closesDEV-51
