### PR TITLE
[DEV-61] Environment.xcconfig 없이도 tuist generate 가능하도록 수정

### DIFF
--- a/iOS/App/Project.swift
+++ b/iOS/App/Project.swift
@@ -1,4 +1,10 @@
+import Foundation
 import ProjectDescription
+
+let xconfigPath = URL(fileURLWithPath: #file)
+    .deletingLastPathComponent()
+    .appendingPathComponent("Environment.xcconfig")
+let xconfigExists = FileManager.default.fileExists(atPath: xconfigPath.path)
 
 let project = Project(
     name: "App",
@@ -59,9 +65,12 @@ let project = Project(
                     "DEVELOPMENT_TEAM": "B3PWYBKFUK",
                     "CODE_SIGN_STYLE": "Automatic",
                 ],
-                configurations: [
+                configurations: xconfigExists ? [
                     .debug(name: "Debug", xcconfig: "Environment.xcconfig"),
                     .release(name: "Release", xcconfig: "Environment.xcconfig")
+                ] : [
+                    .debug(name: "Debug"),
+                    .release(name: "Release")
                 ]
             )
         ),


### PR DESCRIPTION
## Summary
- `Environment.xcconfig` 파일 없이도 `tuist generate` 정상 동작하도록 수정
- xcconfig 파일 존재 여부를 런타임에 확인하여 조건부로 참조
- `API_BASE_URL` 기본값은 `AppContainer`에서 처리하므로 base settings에서 제거

## 변경 사항
- 파일 있으면 → xcconfig 설정 사용
- 파일 없으면 → 기본 configuration 사용 (에러 없이)

## 관련 이슈
- closes #DEV-61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration handling for the iOS app. The project now intelligently checks for configuration files and adapts build settings accordingly, improving flexibility in different build environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->