### PR TITLE
[DEV-62] player 도메인 통일 및 네트워크 플레이어 식별자 uuid로 변경

### DIFF
--- a/iOS/App/Sources/Application/AppContainer.swift
+++ b/iOS/App/Sources/Application/AppContainer.swift
@@ -14,12 +14,12 @@ import StorageKit
 protocol ViewModelFactory {
     func makePermissionSetupViewModel() -> PermissionSetupViewModel
     func makeProfileSetupViewModel() -> ProfileSetupViewModel
-    func makeLobbyViewModel(nickname: String, characterType: String) -> LobbyViewModel
-    func makeGameReadyViewModel(me: LobbyExplorer, peer: LobbyExplorer) -> GameReadyViewModel
+    func makeLobbyViewModel(playerId: UUID, nickname: String, characterType: String) -> LobbyViewModel
+    func makeGameReadyViewModel(me: PlayerInfo, peer: PlayerInfo) -> GameReadyViewModel
     func makeChannelListViewModel() -> ChannelListViewModel
     func makeSettingsViewModel(player: Player) -> SettingsViewModel
     func makeWebSocketSessionManager(serverURL: String) -> WebSocketSessionManager
-    func makeGameViewModel(me: LobbyExplorer, matchPeer: LobbyExplorer?, gameConfig: GameConfigProviding, isNetwork: Bool) -> GameViewModel
+    func makeGameViewModel(localPlayer: PlayerInfo, remotePlayer: PlayerInfo?, gameConfig: GameConfigProviding, isNetwork: Bool) -> GameViewModel
     func makeVideoManager() -> VideoManager
 }
 
@@ -77,17 +77,18 @@ final class AppContainer: ViewModelFactory {
         ProfileSetupViewModel()
     }
     
-    func makeLobbyViewModel(nickname: String, characterType: String) -> LobbyViewModel {
+    func makeLobbyViewModel(playerId: UUID, nickname: String, characterType: String) -> LobbyViewModel {
         LobbyViewModel(
             connectivityMonitor: connectivityMonitor,
             networkSessionManager: networkSessionManager,
             webSocketSessionManager: webSocketSessionManager,
+            playerId: playerId,
             nickname: nickname,
             characterRawValue: characterType
         )
     }
 
-    func makeGameReadyViewModel(me: LobbyExplorer, peer: LobbyExplorer) -> GameReadyViewModel {
+    func makeGameReadyViewModel(me: PlayerInfo, peer: PlayerInfo) -> GameReadyViewModel {
         GameReadyViewModel(
             me: me,
             peer: peer,
@@ -109,10 +110,10 @@ final class AppContainer: ViewModelFactory {
         WebSocketSessionManager(service: webSocketService, serverURL: serverURL)
     }
 
-    func makeGameViewModel(me: LobbyExplorer, matchPeer: LobbyExplorer?, gameConfig: GameConfigProviding, isNetwork: Bool = false) -> GameViewModel {
+    func makeGameViewModel(localPlayer: PlayerInfo, remotePlayer: PlayerInfo?, gameConfig: GameConfigProviding, isNetwork: Bool = false) -> GameViewModel {
         GameViewModel(
-            me: me,
-            matchPeer: matchPeer,
+            localPlayer: localPlayer,
+            remotePlayer: remotePlayer,
             endCondition: TimeoutOrFinishEndCondition(limit: 60, targetPlatformIndex: 10),
             connectionSessionManager: isNetwork ? webSocketSessionManager ?? networkSessionManager : networkSessionManager,
             gameConfig: gameConfig

--- a/iOS/App/Sources/Application/AppFlow/AppRoute.swift
+++ b/iOS/App/Sources/Application/AppFlow/AppRoute.swift
@@ -16,9 +16,9 @@ enum AppRoute: Hashable {
     case dashboard
 
     // Game
-    case gameReady(me: LobbyExplorer, peer: LobbyExplorer)
-    case game(LobbyExplorer?, isNetwork: Bool = false) // TODO: 나중에 이름 변경
-    case operationGuide(me: LobbyExplorer, peer: LobbyExplorer?, isNetwork: Bool)
-    case victoryGuide(me: LobbyExplorer, peer: LobbyExplorer?, isNetwork: Bool)
+    case gameReady(me: PlayerInfo, peer: PlayerInfo)
+    case game(PlayerInfo?, isNetwork: Bool = false) // TODO: 나중에 이름 변경
+    case operationGuide(me: PlayerInfo, peer: PlayerInfo?, isNetwork: Bool)
+    case victoryGuide(me: PlayerInfo, peer: PlayerInfo?, isNetwork: Bool)
     case result
 }

--- a/iOS/App/Sources/Presentation/Game/GameplayIO/MultiplayerNetworkIO.swift
+++ b/iOS/App/Sources/Presentation/Game/GameplayIO/MultiplayerNetworkIO.swift
@@ -13,14 +13,14 @@ import NetworkKit
 
 actor MultiplayerNetworkIO {
     private let localPlayerID: UUID
-    private let otherPlayerIDs: [UUID]
+    private let remotePlayerIDs: [UUID]
     private let gameplayManager: GameplayManager
     private let inputProvider: FaceTrackingGameInputProvider
     private var connectionSessionManager: ConnectionSessionManaging
 
     private let jsonDecoder = JSONDecoder()
 
-    private var peerName: String?
+    private var peerId: UUID?
 
     private var remoteSendTask: Task<Void, Never>?
     private var movementSendAccumulator: TimeInterval = 0
@@ -53,13 +53,13 @@ actor MultiplayerNetworkIO {
 
     init(
         localPlayerID: UUID,
-        otherPlayerIDs: [UUID],
+        remotePlayerIDs: [UUID],
         gameplayManager: GameplayManager,
         inputProvider: FaceTrackingGameInputProvider,
         networkSessionManager: ConnectionSessionManaging
     ) {
         self.localPlayerID = localPlayerID
-        self.otherPlayerIDs = otherPlayerIDs
+        self.remotePlayerIDs = remotePlayerIDs
         self.gameplayManager = gameplayManager
         self.inputProvider = inputProvider
         self.connectionSessionManager = networkSessionManager
@@ -67,8 +67,8 @@ actor MultiplayerNetworkIO {
 
     // MARK: - Public entrypoints (non-async friendly)
 
-    nonisolated func bind(peerName: String) {
-        Task { await self.bindAsync(peerName: peerName) }
+    nonisolated func bind(peerId: UUID) {
+        Task { await self.bindAsync(peerId: peerId) }
     }
 
     nonisolated func unbind() {
@@ -84,8 +84,8 @@ actor MultiplayerNetworkIO {
 
     // MARK: - Actor-isolated implementations
 
-    private func bindAsync(peerName: String) async {
-        self.peerName = peerName
+    private func bindAsync(peerId: UUID) async {
+        self.peerId = peerId
 
         resetTransientState()
 
@@ -107,7 +107,7 @@ actor MultiplayerNetworkIO {
     }
 
     private func unbindAsync() async {
-        peerName = nil
+        peerId = nil
 
         remoteSendTask?.cancel()
         remoteSendTask = nil
@@ -120,7 +120,7 @@ actor MultiplayerNetworkIO {
     }
 
     private func tickAsync(deltaTime: TimeInterval) async {
-        guard peerName != nil else { return }
+        guard peerId != nil else { return }
         await sendMovementSnapshotIfNeeded(deltaTime: deltaTime)
         await updateRemoteInterpolation(deltaTime: deltaTime)
     }
@@ -134,9 +134,9 @@ actor MultiplayerNetworkIO {
         }
     }
 
-    private func handleReceivedInput(sender: String, payload: Data) async {
-        guard let peerName = self.peerName, sender == peerName else { return }
-        guard let remotePlayerID = self.otherPlayerIDs.first else { return }
+    private func handleReceivedInput(sender: UUID, payload: Data) async {
+        guard let peerId = self.peerId, sender == peerId else { return }
+        guard let remotePlayerID = self.remotePlayerIDs.first else { return }
 
         guard let dto = try? self.jsonDecoder.decode(NetworkGameInputDTO.self, from: payload) else {
             return
@@ -177,14 +177,14 @@ actor MultiplayerNetworkIO {
 
     private func handleLocalRespawnConfirmed(playerID: UUID, reason: RespawnReason, position: RespawnPosition) async {
         guard playerID == self.localPlayerID else { return }
-        guard let peerName = self.peerName else { return }
+        guard let peerId = self.peerId else { return }
 
         let dto = NetworkGameInputDTO.respawnRequested(
             reason: self.encodeRespawnReason(reason),
             x: position.x,
             y: position.y
         )
-        self.sendDTO(dto, to: peerName)
+        self.sendDTO(dto, to: peerId)
     }
     
     private func encodeRespawnReason(_ reason: RespawnReason) -> Int {
@@ -245,14 +245,14 @@ actor MultiplayerNetworkIO {
 
     private func handleLocalJumpTriggered(playerID: UUID) async {
         guard playerID == self.localPlayerID else { return }
-        guard let peerName = self.peerName else { return }
-        self.sendDTO(.jumpTriggered, to: peerName)
+        guard let peerId = self.peerId else { return }
+        self.sendDTO(.jumpTriggered, to: peerId)
     }
 
     // MARK: - Tick send + smoothing
 
     private func sendMovementSnapshotIfNeeded(deltaTime: TimeInterval) async {
-        guard let peerName = peerName else { return }
+        guard let peerId = peerId else { return }
 
         timeSinceLastMovementSend += deltaTime
         movementSendAccumulator += deltaTime
@@ -275,11 +275,11 @@ actor MultiplayerNetworkIO {
         // 전송 성공 기준으로 reset
         timeSinceLastMovementSend = 0
         lastSentMoveX = quantized
-        sendDTO(.horizontal(quantized), to: peerName)
+        sendDTO(.horizontal(quantized), to: peerId)
     }
 
     private func updateRemoteInterpolation(deltaTime: TimeInterval) async {
-        guard let remotePlayerID = otherPlayerIDs.first else { return }
+        guard let remotePlayerID = remotePlayerIDs.first else { return }
 
         // liveness: 일정 시간 수신이 없으면 안전하게 멈추기
         let now = Date().timeIntervalSince1970
@@ -298,7 +298,7 @@ actor MultiplayerNetworkIO {
         }
     }
 
-    private func sendDTO(_ dto: NetworkGameInputDTO, to peerName: String) {
-        connectionSessionManager.sendInput(dto, to: peerName)
+    private func sendDTO(_ dto: NetworkGameInputDTO, to peerId: UUID) {
+        connectionSessionManager.sendInput(dto, to: peerId)
     }
 }

--- a/iOS/App/Sources/Presentation/Game/Model/GamePlayerRole.swift
+++ b/iOS/App/Sources/Presentation/Game/Model/GamePlayerRole.swift
@@ -5,7 +5,7 @@
 //  Created by sungkug_apple_developer_ac on 1/14/26.
 //
 
-enum PlayerRole: String {
-    case me
-    case others // 경쟁, 협력모드 고려
+enum GamePlayerRole: String {
+    case local
+    case remote // 경쟁, 협력모드 고려
 }

--- a/iOS/App/Sources/Presentation/Game/Scene/Controller/CharacterController.swift
+++ b/iOS/App/Sources/Presentation/Game/Scene/Controller/CharacterController.swift
@@ -13,7 +13,7 @@ final class CharacterController {
     private weak var scene: SKScene?
     private let cameraSystem: CameraSystem
     
-    let playerRole: PlayerRole
+    let playerRole: GamePlayerRole
 
     private(set) var playerNode: SKSpriteNode?
     private(set) var physicsCore: PhysicsCore?
@@ -32,7 +32,7 @@ final class CharacterController {
     }
     var velocityDY: CGFloat { playerNode?.physicsBody?.velocity.dy ?? 0 }
     
-    init(scene: SKScene, cameraSystem: CameraSystem, playerRole: PlayerRole = .me) {
+    init(scene: SKScene, cameraSystem: CameraSystem, playerRole: GamePlayerRole = .local) {
         self.scene = scene
         self.cameraSystem = cameraSystem
         self.playerRole = playerRole
@@ -51,7 +51,7 @@ final class CharacterController {
         player.size = size
         player.position = initialPosition
         
-        if playerRole == .others {
+        if playerRole == .remote {
             player.alpha = 0.4
         }
         
@@ -59,7 +59,7 @@ final class CharacterController {
         body.isDynamic = true
         body.allowsRotation = false
         
-        if playerRole == .me {
+        if playerRole == .local {
             body.categoryBitMask = PhysicsCategory.playerMe.rawValue
             
             let collidesWith: PhysicsCategory = [.groundMe, .wall]
@@ -183,7 +183,7 @@ extension CharacterController {
         guard let playerNode else { return }
 
         // 반투명(로컬만 투명도 적용)
-        if playerRole == .me {
+        if playerRole == .local {
             playerNode.alpha = 0.25
         }
         
@@ -207,7 +207,7 @@ extension CharacterController {
         guard let playerNode else { return }
 
         // 투명도 복구(로컬만 투명도 복구)
-        if playerRole == .me {
+        if playerRole == .local {
             playerNode.alpha = 1.0
         }
 

--- a/iOS/App/Sources/Presentation/Game/Scene/GameScene.swift
+++ b/iOS/App/Sources/Presentation/Game/Scene/GameScene.swift
@@ -16,12 +16,12 @@ final class GameScene: SKScene {
     private var monsterController: MonsterController?
 
     // 플레이어 메타(아바타) - 전달이 없으면 기본값 사용
-    private let localExplorer: LobbyExplorer?
-    private let otherExplorersByID: [UUID: LobbyExplorer]
+    private let localPlayer: PlayerInfo?
+    private let remotePlayersByID: [UUID: PlayerInfo]
     
     // PlayerID 기반으로 캐릭터 컨트롤러를 관리
     private let localPlayerID: UUID
-    private let otherPlayerIDs: [UUID]
+    private let remotePlayerIDs: [UUID]
     private var characterControllers: [UUID: CharacterController] = [:]
     
     private let outOfBoundsMargin: CGFloat = 100
@@ -32,14 +32,14 @@ final class GameScene: SKScene {
     init(
         size: CGSize,
         gameplayManager: GameplayManager,
-        localExplorer: LobbyExplorer? = nil,
-        otherExplorersByID: [UUID: LobbyExplorer] = [:]
+        localPlayer: PlayerInfo? = nil,
+        remotePlayersByID: [UUID: PlayerInfo] = [:]
     ) {
         self.gameplayManager = gameplayManager
         self.localPlayerID = gameplayManager.localPlayerID
-        self.otherPlayerIDs = gameplayManager.otherPlayerIDs
-        self.localExplorer = localExplorer
-        self.otherExplorersByID = otherExplorersByID
+        self.remotePlayerIDs = gameplayManager.remotePlayerIDs
+        self.localPlayer = localPlayer
+        self.remotePlayersByID = remotePlayersByID
         self.goalPlatformIndex = gameplayManager.getGoalPlatformIndex()
         super.init(size: size)
         self.physicsWorld.gravity = CGVector(dx: 0, dy: PhysicsConstants.gravityDY)
@@ -48,9 +48,9 @@ final class GameScene: SKScene {
 
     required init?(coder: NSCoder) {
         self.localPlayerID = UUID()
-        self.otherPlayerIDs = []
-        self.localExplorer = nil
-        self.otherExplorersByID = [:]
+        self.remotePlayerIDs = []
+        self.localPlayer = nil
+        self.remotePlayersByID = [:]
         self.goalPlatformIndex = 1
         super.init(coder: coder)
     }
@@ -70,8 +70,8 @@ final class GameScene: SKScene {
         setupWalls()
 
         // 캐릭터 설정 (항상 로컬 플레이어는 생성)
-        let localController = CharacterController(scene: self, cameraSystem: cameraSystem, playerRole: .me)
-        let localAvatar = localExplorer?.avatar ?? .character1
+        let localController = CharacterController(scene: self, cameraSystem: cameraSystem, playerRole: .local)
+        let localAvatar = localPlayer?.avatar ?? .character1
         localController.setupPlayer(characterType: localAvatar)
         if let node = localController.playerNode {
             node.name = "\(L10N.Game.NodeName.player):\(localPlayerID.uuidString)"
@@ -79,9 +79,9 @@ final class GameScene: SKScene {
         characterControllers[localPlayerID] = localController
         
         // 상대 플레이어들 생성
-        for id in otherPlayerIDs where id != localPlayerID {
-            let opponentController = CharacterController(scene: self, cameraSystem: cameraSystem, playerRole: .others)
-            let opponentAvatar = otherExplorersByID[id]?.avatar ?? .character1
+        for id in remotePlayerIDs where id != localPlayerID {
+            let opponentController = CharacterController(scene: self, cameraSystem: cameraSystem, playerRole: .remote)
+            let opponentAvatar = remotePlayersByID[id]?.avatar ?? .character1
             opponentController.setupPlayer(characterType: opponentAvatar)
             if let node = opponentController.playerNode {
                 node.name = "\(L10N.Game.NodeName.player):\(id.uuidString)"
@@ -211,7 +211,7 @@ final class GameScene: SKScene {
         let localBottomY = characterControllers[localPlayerID]?.bottomY
         let localDY = characterControllers[localPlayerID]?.velocityDY
 
-        let otherID = otherPlayerIDs.first(where: { $0 != localPlayerID })
+        let otherID = remotePlayerIDs.first(where: { $0 != localPlayerID })
         let otherBottomY = otherID.flatMap { characterControllers[$0]?.bottomY }
         let otherDY = otherID.flatMap { characterControllers[$0]?.velocityDY }
 

--- a/iOS/App/Sources/Presentation/Game/View/GameView.swift
+++ b/iOS/App/Sources/Presentation/Game/View/GameView.swift
@@ -108,9 +108,9 @@ struct GameView: View {
     }
 
     private func setupGame() {
-        let otherExplorersByID: [UUID: LobbyExplorer] = {
-            guard let peer = viewModel.matchPeer,
-                  let remoteID = viewModel.otherPlayerIDs.first else {
+        let remotePlayersByID: [UUID: PlayerInfo] = {
+            guard let peer = viewModel.remotePlayer,
+                  let remoteID = viewModel.remotePlayerIDs.first else {
                 return [:]
             }
             return [remoteID: peer]
@@ -119,8 +119,8 @@ struct GameView: View {
         let scene = GameScene(
             size: UIScreen.main.bounds.size,
             gameplayManager: gameplayManager,
-            localExplorer: viewModel.me,
-            otherExplorersByID: otherExplorersByID
+            localPlayer: viewModel.localPlayer,
+            remotePlayersByID: remotePlayersByID
         )
         scene.scaleMode = .aspectFill
         scene.backgroundColor = .clear

--- a/iOS/App/Sources/Presentation/Game/View/GameViewModel.swift
+++ b/iOS/App/Sources/Presentation/Game/View/GameViewModel.swift
@@ -13,15 +13,13 @@ import NetworkKit
 @MainActor
 @Observable
 final class GameViewModel {
-    public let me: LobbyExplorer
-    public let matchPeer: LobbyExplorer?
+    public let localPlayer: PlayerInfo
+    public let remotePlayer: PlayerInfo?
     
-    // TODO: 닉네임이나 id 둘중 하나로 관리되게 통일하기
-    var myNickname: String { me.displayName }
-    var matchNickname: String? { matchPeer?.displayName }
+    var remotePlayerId: UUID? { remotePlayer?.id }
 
     public let localPlayerID: UUID
-    public let otherPlayerIDs: [UUID]
+    public let remotePlayerIDs: [UUID]
     
     let gameplayManager: GameplayManager
     let gameConfig: GameConfigProviding
@@ -50,14 +48,14 @@ final class GameViewModel {
     }
     
     init(
-        me: LobbyExplorer,
-        matchPeer: LobbyExplorer?,
+        localPlayer: PlayerInfo,
+        remotePlayer: PlayerInfo?,
         endCondition: any GameEndCondition,
         connectionSessionManager: ConnectionSessionManaging,
         gameConfig: GameConfigProviding
     ) {
-        self.me = me
-        self.matchPeer = matchPeer
+        self.localPlayer = localPlayer
+        self.remotePlayer = remotePlayer
         self.connectionSessionManager = connectionSessionManager
         self.gameConfig = gameConfig
         self.inputProvider = FaceTrackingGameInputProvider(
@@ -65,23 +63,23 @@ final class GameViewModel {
             tiltSensitivity: gameConfig.tiltSensitivity
         )
         
-        self.localPlayerID = UUID()
+        self.localPlayerID = localPlayer.id
         
-        if matchPeer != nil {
-            self.otherPlayerIDs = [UUID()]
+        if let remotePlayer {
+            self.remotePlayerIDs = [remotePlayer.id]
         } else {
-            self.otherPlayerIDs = []
+            self.remotePlayerIDs = []
         }
         
         self.gameplayManager = GameplayManager(
             localPlayerID: localPlayerID,
-            otherPlayerIDs: otherPlayerIDs,
+            remotePlayerIDs: remotePlayerIDs,
             endCondition: endCondition
         )
         
         self.multiplayerIO = MultiplayerNetworkIO(
             localPlayerID: localPlayerID,
-            otherPlayerIDs: otherPlayerIDs,
+            remotePlayerIDs: remotePlayerIDs,
             gameplayManager: gameplayManager,
             inputProvider: inputProvider,
             networkSessionManager: connectionSessionManager
@@ -94,8 +92,8 @@ final class GameViewModel {
         gameplayManager.bind(input: inputProvider, for: localPlayerID)
         
         // 네트워크 송신/수신 바인딩 (멀티플레이일 때만)
-        if let matchNickname {
-            multiplayerIO?.bind(peerName: matchNickname)
+        if let remotePlayerId {
+            multiplayerIO?.bind(peerId: remotePlayerId)
         } else {
             multiplayerIO?.unbind()
         }

--- a/iOS/App/Sources/Presentation/GameReady/GameReadyView.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GameReadyView.swift
@@ -22,14 +22,14 @@ struct GameReadyView: View {
                 Spacer()
 
                 HStack(spacing: 10) {
-                    characterView(explorer: viewModel.me, isMe: true)
+                    characterView(player: viewModel.me, isMe: true)
                         .offset(y: isAnimating ? -15 : 0) // 위아래 둥둥 효과
                         .animation(
                             .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
                             value: isAnimating
                         )
 
-                    characterView(explorer: viewModel.peer, isMe: false)
+                    characterView(player: viewModel.peer, isMe: false)
                         .offset(y: isAnimating ? 0 : -15) // 엇박자로 움직임
                         .animation(
                             .easeInOut(duration: 1.0).repeatForever(autoreverses: true).delay(0.5),
@@ -72,9 +72,9 @@ struct GameReadyView: View {
 
 private extension GameReadyView {
 
-    func characterView(explorer: LobbyExplorer, isMe: Bool) -> some View {
+    func characterView(player: PlayerInfo, isMe: Bool) -> some View {
         VStack(spacing: 10) {
-            explorer.avatar.image
+            player.avatar.image
                 .resizable()
                 .scaledToFit()
                 .frame(width: 130, height: 130)
@@ -114,8 +114,8 @@ struct GameReadyView_Previews: PreviewProvider {
     static var previews: some View {
         let container = AppContainer()
         GameReadyView(
-            viewModel: container.makeGameReadyViewModel(me: LobbyExplorer(role: .me, displayName: "나", avatar: .character1),
-                                                        peer: LobbyExplorer(role: .peer, displayName: "상대", avatar: .character2))
+            viewModel: container.makeGameReadyViewModel(me: PlayerInfo(role: .me, displayName: "나", avatar: .character1),
+                                                        peer: PlayerInfo(role: .peer, displayName: "상대", avatar: .character2))
         )
     }
 }

--- a/iOS/App/Sources/Presentation/GameReady/GameReadyViewModel.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GameReadyViewModel.swift
@@ -11,8 +11,8 @@ import NetworkKit
 @MainActor
 @Observable
 final class GameReadyViewModel {
-    let me: LobbyExplorer
-    let peer: LobbyExplorer
+    let me: PlayerInfo
+    let peer: PlayerInfo
 
     private(set) var isMeReady: Bool = false
     private(set) var isPeerReady: Bool = false
@@ -32,8 +32,8 @@ final class GameReadyViewModel {
     let webSocketSessionManager: WebSocketSessionManaging?
 
     init(
-        me: LobbyExplorer,
-        peer: LobbyExplorer,
+        me: PlayerInfo,
+        peer: PlayerInfo,
         connectivityMonitor: ConnectivityMonitoring,
         networkSessionManager: NetworkSessionManaging,
         webSocketSessionManager: WebSocketSessionManaging?
@@ -81,10 +81,10 @@ final class GameReadyViewModel {
     }
 
     private func setupP2PCallbacks() {
-        networkSessionManager.onReadyStatusReceived = { [weak self] senderName in
+        networkSessionManager.onReadyStatusReceived = { [weak self] senderId in
             guard let self else { return }
 
-            guard senderName == self.peer.displayName else { return }
+            guard senderId == self.peer.id else { return }
 
             Task { @MainActor in
                 self.handlePeerReady()
@@ -93,10 +93,10 @@ final class GameReadyViewModel {
     }
 
     private func setupWebSocketCallbacks() {
-        webSocketSessionManager?.onReadyStatusReceived = { [weak self] senderName in
+        webSocketSessionManager?.onReadyStatusReceived = { [weak self] senderId in
             guard let self else { return }
 
-            guard senderName == self.peer.displayName else { return }
+            guard senderId == self.peer.id else { return }
 
             Task { @MainActor in
                 self.handlePeerReady()
@@ -107,10 +107,10 @@ final class GameReadyViewModel {
     private func sendReadySignal() {
         switch networkMode {
         case .local:
-            networkSessionManager.sendReadyStatus(to: peer.displayName)
+            networkSessionManager.sendReadyStatus(to: peer.id)
 
         case .remote:
-            webSocketSessionManager?.sendReadyStatus(to: peer.displayName)
+            webSocketSessionManager?.sendReadyStatus(to: peer.id)
         }
     }
 

--- a/iOS/App/Sources/Presentation/GameReady/GuideView/OperationGuideView.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GuideView/OperationGuideView.swift
@@ -11,8 +11,8 @@ struct OperationGuideView: View {
     @Environment(AppRouter.self) private var router: AppRouter
     @State private var isChecked: Bool = UserDefaultsList.Game.isGuideChecked
 
-    let me: LobbyExplorer
-    let peer: LobbyExplorer?
+    let me: PlayerInfo
+    let peer: PlayerInfo?
     let isNetwork: Bool
     
     var body: some View {
@@ -118,8 +118,8 @@ private extension OperationGuideView {
 }
 
 #Preview {
-    OperationGuideView(me: LobbyExplorer(role: .me, displayName: "나", avatar: .character1),
-                       peer: LobbyExplorer(role: .peer, displayName: "상대", avatar: .character2),
+    OperationGuideView(me: PlayerInfo(role: .me, displayName: "나", avatar: .character1),
+                       peer: PlayerInfo(role: .peer, displayName: "상대", avatar: .character2),
                        isNetwork: false)
         .environment(AppRouter())
 }

--- a/iOS/App/Sources/Presentation/GameReady/GuideView/VictoryGuideView.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GuideView/VictoryGuideView.swift
@@ -11,8 +11,8 @@ struct VictoryGuideView: View {
     @Environment(AppRouter.self) private var router: AppRouter
     @State private var isChecked: Bool = UserDefaultsList.Game.isGuideChecked
 
-    let me: LobbyExplorer
-    let peer: LobbyExplorer?
+    let me: PlayerInfo
+    let peer: PlayerInfo?
     let isNetwork: Bool
     
     var body: some View {
@@ -84,8 +84,8 @@ struct VictoryGuideView: View {
 }
 
 #Preview {
-    VictoryGuideView(me: LobbyExplorer(role: .me, displayName: "나", avatar: .character1),
-                     peer: LobbyExplorer(role: .peer, displayName: "상대", avatar: .character2),
+    VictoryGuideView(me: PlayerInfo(role: .me, displayName: "나", avatar: .character1),
+                     peer: PlayerInfo(role: .peer, displayName: "상대", avatar: .character2),
                      isNetwork: false)
         .environment(AppRouter())
 }

--- a/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
+++ b/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
@@ -58,7 +58,7 @@ struct LobbyView: View {
                 if UserDefaultsList.Game.isGuideChecked {
                     router.push(.game(peer, isNetwork: viewModel.networkMode == .remote))
                 } else {
-                    router.push(.operationGuide(me: viewModel.myExplorer,
+                    router.push(.operationGuide(me: viewModel.localPlayer,
                                                 peer: peer, isNetwork: viewModel.networkMode == .remote))
                 }
             }
@@ -124,7 +124,7 @@ private extension LobbyView {
             .padding(.top, 40)
             .padding(.horizontal, 30)
         
-        explorerOrbitSelector
+        playerOrbitSelector
         
         Spacer()
         
@@ -184,7 +184,7 @@ private extension LobbyView {
                 if UserDefaultsList.Game.isGuideChecked {
                     router.push(.game(nil))
                 } else {
-                    router.push(.operationGuide(me: viewModel.myExplorer, peer: nil, isNetwork: viewModel.networkMode == .remote))
+                    router.push(.operationGuide(me: viewModel.localPlayer, peer: nil, isNetwork: viewModel.networkMode == .remote))
                 }
             }
             
@@ -251,7 +251,7 @@ private extension LobbyView {
     var greetingCard: some View {
         VStack(spacing: 4) {
             HStack(spacing: 0) {
-                Text(viewModel.myExplorer.displayName)
+                Text(viewModel.localPlayer.displayName)
                     .font(AppFontFamily.Pretendard.bold.swiftUIFont(size: 22))
                 Text(L10N.Lobby.greetingSuffix)
                     .font(AppFontFamily.Pretendard.medium.swiftUIFont(size: 22))
@@ -276,10 +276,10 @@ private extension LobbyView {
     }
 }
 
-// MARK: - Explorer Orbit Selector
+// MARK: - Player Orbit Selector
 
 private extension LobbyView {
-    var explorerOrbitSelector: some View {
+    var playerOrbitSelector: some View {
         let displayPeers = viewModel.orderedPeers.prefix(OrbitSlot.orderedSlots.count)
         let isZoomedOut = displayPeers.count > 5
         let radarScale: CGFloat = isAppearing ? (isZoomedOut ? 0.8 : 1.0) : 0.1
@@ -292,23 +292,23 @@ private extension LobbyView {
                 ZStack {
                     radarRings(size: size, center: center, isZoomedOut: isZoomedOut)
 
-                    ForEach(Array(displayPeers.enumerated()), id: \.element.id) { index, explorer in
+                    ForEach(Array(displayPeers.enumerated()), id: \.element.id) { index, player in
                         let position = calculatePosition(
                             index: index,
-                            proximity: explorer.proximity,
+                            proximity: player.proximity,
                             size: size,
                             center: center,
                             isZoomedOut: isZoomedOut
                         )
 
-                        peerExplorerView(explorer: explorer)
+                        peerPlayerView(player: player)
                             .position(position)
-                            .id(explorer.id)
+                            .id(player.id)
                     }
                 }
                 .scaleEffect(radarScale)
 
-                myExplorerView
+                localPlayerView
                     .position(center)
             }
             .animation(.spring(response: 0.6, dampingFraction: 0.7), value: radarScale)
@@ -364,17 +364,17 @@ private extension LobbyView {
     }
 }
 
-// MARK: - Explorer Views
+// MARK: - Player Views
 
 private extension LobbyView {
-    var myExplorerView: some View {
+    var localPlayerView: some View {
         let labelOffset: CGFloat = -70
 
         return ZStack {
-            explorerLabel(text: viewModel.myExplorer.displayName)
+            playerLabel(text: viewModel.localPlayer.displayName)
                 .offset(y: labelOffset)
 
-            viewModel.myExplorer.avatar.image
+            viewModel.localPlayer.avatar.image
                 .resizable()
                 .scaledToFit()
                 .frame(width: 100, height: 100)
@@ -391,15 +391,15 @@ private extension LobbyView {
         }
     }
 
-    func peerExplorerView(explorer: LobbyExplorer) -> some View {
-        let isSelected = viewModel.selectedPeerID == explorer.id
+    func peerPlayerView(player: PlayerInfo) -> some View {
+        let isSelected = viewModel.selectedPeerID == player.id
         let labelOffset: CGFloat = -50
 
         return ZStack {
-            explorerLabel(text: explorer.displayName)
+            playerLabel(text: player.displayName)
                 .offset(y: labelOffset)
 
-            explorer.avatar.image
+            player.avatar.image
                 .resizable()
                 .scaledToFit()
                 .frame(width: 70, height: 70)
@@ -422,12 +422,12 @@ private extension LobbyView {
         }
         .onTapGesture {
             withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                viewModel.selectPeer(explorer)
+                viewModel.selectPeer(player)
             }
         }
     }
 
-    func explorerLabel(text: String) -> some View {
+    func playerLabel(text: String) -> some View {
         Text(text)
             .font(AppFontFamily.Pretendard.semiBold.swiftUIFont(size: 12))
             .foregroundStyle(AppAsset.Color.blackLabel.swiftUIColor)
@@ -485,7 +485,7 @@ private extension LobbyView {
 
 // MARK: - Request Modal Views
 private extension LobbyView {
-    func requestModal(peer: LobbyExplorer) -> some View {
+    func requestModal(peer: PlayerInfo) -> some View {
         let isSending: Bool = {
             if case .sendingRequest = viewModel.matchStatus { return true }
             return false
@@ -518,7 +518,7 @@ private extension LobbyView {
             .foregroundStyle(AppAsset.Color.mainLabel.swiftUIColor)
     }
 
-    func modalAvatarView(for peer: LobbyExplorer, isGrayscale: Bool) -> some View {
+    func modalAvatarView(for peer: PlayerInfo, isGrayscale: Bool) -> some View {
         ZStack {
             Circle()
                 .fill(.white.opacity(0.5))
@@ -534,7 +534,7 @@ private extension LobbyView {
         }
     }
 
-    func modalDisplayName(for peer: LobbyExplorer) -> some View {
+    func modalDisplayName(for peer: PlayerInfo) -> some View {
         Text(peer.displayName)
             .font(AppFontFamily.Pretendard.semiBold.swiftUIFont(size: 20))
             .foregroundStyle(AppAsset.Color.mainLabel.swiftUIColor)
@@ -577,7 +577,7 @@ private extension LobbyView {
 // MARK: - Decline Modal Views
 
 private extension LobbyView {
-    func declineModal(peer: LobbyExplorer) -> some View {
+    func declineModal(peer: PlayerInfo) -> some View {
         VStack(spacing: 24) {
             modalTitle(L10N.Lobby.DeclineModal.invitationDeclinedTitle)
 
@@ -596,7 +596,7 @@ private extension LobbyView {
         .shadow(radius: 10)
     }
 
-    func declineModalMessage(for peer: LobbyExplorer) -> some View {
+    func declineModalMessage(for peer: PlayerInfo) -> some View {
         (Text("'\(peer.displayName)'") +
          Text(L10N.Lobby.DeclineModal.invitationDeclinedMessage))
         .font(AppFontFamily.Pretendard.medium.swiftUIFont(size: 18))
@@ -628,7 +628,7 @@ private extension LobbyView {
 // MARK: - 초대 수신 Bottom Sheet
 
 private extension LobbyView {
-    func inviteReceivedSheet(peer: LobbyExplorer) -> some View {
+    func inviteReceivedSheet(peer: PlayerInfo) -> some View {
         VStack(spacing: 24) {
             inviteSheetHeader
 
@@ -666,7 +666,7 @@ private extension LobbyView {
         }
     }
 
-    func inviteSheetContent(for peer: LobbyExplorer) -> some View {
+    func inviteSheetContent(for peer: PlayerInfo) -> some View {
         HStack(spacing: 16) {
             ZStack {
                 Circle()
@@ -723,7 +723,7 @@ struct LobbyView_Previews: PreviewProvider {
     static var previews: some View {
         let container = AppContainer()
         LobbyView(
-            viewModel: container.makeLobbyViewModel(nickname: "코스믹어드벤처", characterType: "character1"),
+            viewModel: container.makeLobbyViewModel(playerId: UUID(), nickname: "코스믹어드벤처", characterType: "character1"),
             channelListViewModel: container.makeChannelListViewModel()
         )
     }

--- a/iOS/App/Sources/Presentation/Lobby/Model/GameMatchStatus.swift
+++ b/iOS/App/Sources/Presentation/Lobby/Model/GameMatchStatus.swift
@@ -9,17 +9,17 @@ import Foundation
 
 enum GameMatchStatus: Equatable {
     case idle
-    case readyToSend(peer: LobbyExplorer)
-    case sendingRequest(peer: LobbyExplorer)
-    case receivedInvite(peer: LobbyExplorer)
-    case requestDeclined(peer: LobbyExplorer)
-    case gameReady(peer: LobbyExplorer)
+    case readyToSend(peer: PlayerInfo)
+    case sendingRequest(peer: PlayerInfo)
+    case receivedInvite(peer: PlayerInfo)
+    case requestDeclined(peer: PlayerInfo)
+    case gameReady(peer: PlayerInfo)
 
     mutating func reset() {
         self = .idle
     }
 
-    mutating func select(_ peer: LobbyExplorer) {
+    mutating func select(_ peer: PlayerInfo) {
         self = .readyToSend(peer: peer)
     }
 
@@ -29,15 +29,15 @@ enum GameMatchStatus: Equatable {
         }
     }
 
-    mutating func requestDeclined(by peer: LobbyExplorer) {
+    mutating func requestDeclined(by peer: PlayerInfo) {
         self = .requestDeclined(peer: peer)
     }
 
-    mutating func receiveInvite(from peer: LobbyExplorer) {
+    mutating func receiveInvite(from peer: PlayerInfo) {
         self = .receivedInvite(peer: peer)
     }
 
-    mutating func setGameReady(with peer: LobbyExplorer) {
+    mutating func setGameReady(with peer: PlayerInfo) {
         self = .gameReady(peer: peer)
     }
 }

--- a/iOS/App/Sources/Presentation/Lobby/Model/LobbyModels.swift
+++ b/iOS/App/Sources/Presentation/Lobby/Model/LobbyModels.swift
@@ -7,41 +7,6 @@
 
 import SwiftUI
 
-// MARK: - Explorer Role
-
-enum ExplorerRole: Equatable {
-    case me
-    case peer
-}
-
-// MARK: - Lobby Explorer
-
-struct LobbyExplorer: Identifiable, Equatable, Hashable {
-    let id: String
-    let role: ExplorerRole
-    let displayName: String
-    let avatar: CharacterAvatar
-    
-    /// 수신 감도/근접도: 0.0~1.0, 값이 클수록 내 위치에 더 가까움
-    /// - nil이면 아직 미측정/알 수 없음
-    /// - peer만 의미 있음 (me는 항상 중앙 고정)
-    var proximity: Double?
-    
-    init(
-        id: String? = nil,
-        role: ExplorerRole,
-        displayName: String,
-        avatar: CharacterAvatar,
-        proximity: Double? = nil
-    ) {
-        self.id = id ?? displayName
-        self.role = role
-        self.displayName = displayName
-        self.avatar = avatar
-        self.proximity = proximity
-    }
-}
-
 // MARK: - Orbit Layout
 
 enum OrbitSlot: CaseIterable {
@@ -130,7 +95,7 @@ enum LobbyAlert {
         case .none: return ""
         }
     }
-    
+
     var hasCancelButton: Bool {
         return self == .permissionDenied
     }

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+P2P.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+P2P.swift
@@ -30,42 +30,39 @@ extension LobbyViewModel {
             }
         }
 
-        networkSessionManager.onInviteReceived = { [weak self] senderName in
+        networkSessionManager.onInviteReceived = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteReceived(from: senderName)
+                self?.handleInviteReceived(from: senderId)
             }
         }
 
-        networkSessionManager.onInviteAccepted = { [weak self] senderName in
+        networkSessionManager.onInviteAccepted = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteAccepted(from: senderName)
+                self?.handleInviteAccepted(from: senderId)
             }
         }
 
-        networkSessionManager.onInviteDeclined = { [weak self] senderName in
+        networkSessionManager.onInviteDeclined = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteDeclined(from: senderName)
+                self?.handleInviteDeclined(from: senderId)
             }
         }
 
-        networkSessionManager.onInviteCancelled = { [weak self] senderName in
+        networkSessionManager.onInviteCancelled = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteCancelled(from: senderName)
+                self?.handleInviteCancelled(from: senderId)
             }
         }
     }
 
-    func updateLocalPeers(_ peers: [Peer]) {
+    func updateLocalPeers(_ peers: [NetworkPeer]) {
         self.peers = peers.enumerated().map { index, peer in
-            let id = peer.name
-            playerIdMapping[peer.name] = id
-
             let discoveryLatency = Double(index * 10 + 5)
             let effectiveLatency = peer.latency ?? discoveryLatency
             let proximity = calculateProximity(latency: effectiveLatency)
-
-            return LobbyExplorer(
-                id: id,
+            
+            return PlayerInfo(
+                id: peer.sessionId,
                 role: .peer,
                 displayName: peer.name,
                 avatar: .character1,

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+WebSocket.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+WebSocket.swift
@@ -26,7 +26,6 @@ extension LobbyViewModel {
                 self?.isConnected = connected
                 if !connected {
                     self?.peers = []
-                    self?.playerIdMapping = [:]
                     self?.selectedPeerID = nil
                     self?.matchStatus = .idle
                 }
@@ -55,27 +54,27 @@ extension LobbyViewModel {
     }
 
     private func setupInvitationCallbacks() {
-        webSocketSessionManager?.onInviteReceived = { [weak self] senderName in
+        webSocketSessionManager?.onInviteReceived = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteReceived(from: senderName)
+                self?.handleInviteReceived(from: senderId)
             }
         }
 
-        webSocketSessionManager?.onInviteAccepted = { [weak self] senderName in
+        webSocketSessionManager?.onInviteAccepted = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteAccepted(from: senderName)
+                self?.handleInviteAccepted(from: senderId)
             }
         }
 
-        webSocketSessionManager?.onInviteDeclined = { [weak self] senderName in
+        webSocketSessionManager?.onInviteDeclined = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteDeclined(from: senderName)
+                self?.handleInviteDeclined(from: senderId)
             }
         }
 
-        webSocketSessionManager?.onInviteCancelled = { [weak self] senderName in
+        webSocketSessionManager?.onInviteCancelled = { [weak self] senderId in
             Task { @MainActor in
-                self?.handleInviteCancelled(from: senderName)
+                self?.handleInviteCancelled(from: senderId)
             }
         }
     }
@@ -86,11 +85,9 @@ extension LobbyViewModel {
 extension LobbyViewModel {
 
     func updatePeersFromPlayers(_ players: [WebSocketPlayer]) {
-        playerIdMapping.removeAll()
         peers = players.map { player in
-            playerIdMapping[player.id] = player.id
             let proximity = calculateProximity(latency: player.latency)
-            return LobbyExplorer(
+            return PlayerInfo(
                 id: player.id,
                 role: .peer,
                 displayName: player.nickname,
@@ -101,28 +98,24 @@ extension LobbyViewModel {
     }
 
     func addPeer(from player: WebSocketPlayer) {
-        guard playerIdMapping[player.id] == nil else { return }
-
-        playerIdMapping[player.id] = player.id
+        guard peers.contains(where: { $0.id == player.id }) == false else { return }
 
         let proximity = calculateProximity(latency: player.latency)
 
-        let explorer = LobbyExplorer(
+        let player = PlayerInfo(
             id: player.id,
             role: .peer,
             displayName: player.nickname,
             avatar: randomAvatar(),
             proximity: proximity
         )
-        peers.append(explorer)
+        peers.append(player)
     }
 
-    func removePeer(playerId: String) {
-        guard let id = playerIdMapping[playerId] else { return }
-        peers.removeAll { $0.id == id }
-        playerIdMapping.removeValue(forKey: playerId)
+    func removePeer(playerId: UUID) {
+        peers.removeAll { $0.id == playerId }
 
-        if selectedPeerID == id {
+        if selectedPeerID == playerId {
             selectedPeerID = nil
         }
     }

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
@@ -23,10 +23,10 @@ final class LobbyViewModel {
     
     private let logger = Logger(subsystem: "com.cosmicadventure.app", category: "LobbyViewModel")
 
-    // Explorer
-    private(set) var myExplorer: LobbyExplorer
-    var peers: [LobbyExplorer] = []
-    var selectedPeerID: String?
+    // Player
+    private(set) var localPlayer: PlayerInfo
+    var peers: [PlayerInfo] = []
+    var selectedPeerID: UUID?
 
     // UI State
     var activeAlert: LobbyAlert = .none
@@ -52,9 +52,6 @@ final class LobbyViewModel {
     @ObservationIgnored
     let webSocketSessionManager: WebSocketSessionManaging?
 
-    // Internal State
-    @ObservationIgnored
-    var playerIdMapping: [String: String] = [:]
 
     // MARK: - Computed Properties
 
@@ -62,7 +59,7 @@ final class LobbyViewModel {
         connectivityMonitor.isConnected
     }
 
-    var orderedPeers: [LobbyExplorer] {
+    var orderedPeers: [PlayerInfo] {
         peers.sorted { lhs, rhs in
             switch (lhs.proximity, rhs.proximity) {
             case let (l?, r?): return l < r
@@ -79,6 +76,7 @@ final class LobbyViewModel {
         connectivityMonitor: ConnectivityMonitoring,
         networkSessionManager: NetworkSessionManaging,
         webSocketSessionManager: WebSocketSessionManaging?,
+        playerId: UUID,
         nickname: String,
         characterRawValue: String
     ) {
@@ -87,7 +85,8 @@ final class LobbyViewModel {
         self.webSocketSessionManager = webSocketSessionManager
         self.selectedPeerID = nil
         
-        self.myExplorer = LobbyExplorer(
+        self.localPlayer = PlayerInfo(
+            id: playerId,
             role: .me,
             displayName: nickname,
             avatar: CharacterAvatar(rawValue: characterRawValue) ?? .character1
@@ -140,16 +139,18 @@ extension LobbyViewModel {
     }
 
     func startNetworkExploration() {
+        resetToIdle()
+
         switch networkMode {
         case .local:
             setupSessionManager()
-            networkSessionManager.activate(nickname: myExplorer.displayName)
+            networkSessionManager.activate(nickname: localPlayer.displayName)
         case .remote:
             guard let channelId = selectedChannelId else {
                 logger.warning("Remote 모드지만 selectedChannelId가 nil")
                 return
             }
-            webSocketSessionManager?.activate(channelId: channelId, nickname: myExplorer.displayName)
+            webSocketSessionManager?.activate(channelId: channelId, nickname: localPlayer.displayName)
         }
     }
 
@@ -175,16 +176,16 @@ extension LobbyViewModel {
     }
 }
 
-// MARK: - Peer Management
+// MARK: - NetworkPeer Management
 
 extension LobbyViewModel {
-    func selectPeer(_ peer: LobbyExplorer) {
+    func selectPeer(_ peer: PlayerInfo) {
         self.selectedPeerID = peer.id
         self.matchStatus.select(peer)
     }
 
-    func updateProximity(for explorerID: String, value: Double) {
-        guard let index = peers.firstIndex(where: { $0.id == explorerID }) else { return }
+    func updateProximity(for playerID: UUID, value: Double) {
+        guard let index = peers.firstIndex(where: { $0.id == playerID }) else { return }
         peers[index].proximity = max(0, min(1, value))
     }
 
@@ -223,14 +224,14 @@ extension LobbyViewModel {
 }
 
 // MARK: - Invite Event Handlers
-// TODO: - UUID 추가 후 id와 name 모두 확인하는 로직으로 수정
+
 extension LobbyViewModel {
-    func handleInviteReceived(from senderIdentifier: String) {
-        guard let peer = peers.first(where: { $0.id == senderIdentifier || $0.displayName == senderIdentifier }) else {
-            logger.warning("초대한 피어를 찾을 수 없음: \(senderIdentifier)")
+    func handleInviteReceived(from senderId: UUID) {
+        guard let peer = peers.first(where: { $0.id == senderId }) else {
+            logger.warning("초대한 피어를 찾을 수 없음: \(senderId.uuidString)")
             return
         }
-
+        
         switch matchStatus {
         case .idle:
             matchStatus.receiveInvite(from: peer)
@@ -239,23 +240,23 @@ extension LobbyViewModel {
         }
     }
 
-    func handleInviteAccepted(from senderIdentifier: String) {
-        guard let peer = peers.first(where: { $0.id == senderIdentifier || $0.displayName == senderIdentifier }) else { return }
+    func handleInviteAccepted(from senderId: UUID) {
+        guard let peer = peers.first(where: { $0.id == senderId }) else { return }
 
         if case .sendingRequest = matchStatus {
             matchStatus.setGameReady(with: peer)
         }
     }
 
-    func handleInviteDeclined(from senderIdentifier: String) {
-        guard let peer = peers.first(where: { $0.id == senderIdentifier || $0.displayName == senderIdentifier }) else { return }
+    func handleInviteDeclined(from senderId: UUID) {
+        guard let peer = peers.first(where: { $0.id == senderId }) else { return }
 
         if case .sendingRequest = matchStatus {
             matchStatus.requestDeclined(by: peer)
         }
     }
 
-    func handleInviteCancelled(from senderName: String) {
+    func handleInviteCancelled(from senderId: UUID) {
         if case .receivedInvite = matchStatus {
             resetToIdle()
         }
@@ -271,12 +272,10 @@ extension LobbyViewModel {
 
         switch networkMode {
         case .local:
-            networkSessionManager.sendInvite(to: peer.displayName)
+            networkSessionManager.sendInvite(to: peer.id)
 
         case .remote:
-            if let playerId = playerIdMapping.first(where: { $0.value == peer.id })?.key {
-                webSocketSessionManager?.sendInvite(to: playerId)
-            }
+            webSocketSessionManager?.sendInvite(to: peer.id)
         }
     }
 
@@ -284,12 +283,10 @@ extension LobbyViewModel {
         if case .sendingRequest(let peer) = matchStatus {
             switch networkMode {
             case .local:
-                networkSessionManager.cancelInvite(to: peer.displayName)
+                networkSessionManager.cancelInvite(to: peer.id)
 
             case .remote:
-                if let playerId = playerIdMapping.first(where: { $0.value == peer.id })?.key {
-                    webSocketSessionManager?.cancelInvite(to: playerId)
-                }
+                webSocketSessionManager?.cancelInvite(to: peer.id)
             }
         }
 
@@ -301,12 +298,10 @@ extension LobbyViewModel {
 
         switch networkMode {
         case .local:
-            networkSessionManager.acceptInvite(from: peer.displayName)
+            networkSessionManager.acceptInvite(from: peer.id)
 
         case .remote:
-            if let playerId = playerIdMapping.first(where: { $0.value == peer.id })?.key {
-                webSocketSessionManager?.acceptInvite(from: playerId)
-            }
+            webSocketSessionManager?.acceptInvite(from: peer.id)
         }
 
         matchStatus.setGameReady(with: peer)
@@ -317,12 +312,10 @@ extension LobbyViewModel {
 
         switch networkMode {
         case .local:
-            networkSessionManager.declineInvite(from: peer.displayName)
+            networkSessionManager.declineInvite(from: peer.id)
 
         case .remote:
-            if let playerId = playerIdMapping.first(where: { $0.value == peer.id })?.key {
-                webSocketSessionManager?.declineInvite(from: playerId)
-            }
+            webSocketSessionManager?.declineInvite(from: peer.id)
         }
 
         resetToIdle()

--- a/iOS/App/Sources/Presentation/Root/RootView.swift
+++ b/iOS/App/Sources/Presentation/Root/RootView.swift
@@ -39,10 +39,11 @@ struct RootView: View {
         case .profileSetup:
             ProfileSetupView(viewModel: viewModelFactory.makeProfileSetupViewModel())
         case .lobby:
-            if let myExplorer = players.first {
+            if let myPlayer = players.first {
                 LobbyView(viewModel:
-                            viewModelFactory.makeLobbyViewModel(nickname: myExplorer.nickname,
-                                                                characterType: myExplorer.character),
+                            viewModelFactory.makeLobbyViewModel(playerId: myPlayer.id,
+                                                                nickname: myPlayer.nickname,
+                                                                characterType: myPlayer.character),
                           channelListViewModel: viewModelFactory.makeChannelListViewModel()
                 )
             }
@@ -56,18 +57,19 @@ struct RootView: View {
         case .gameReady(let me, let peer):
              GameReadyView(viewModel: viewModelFactory.makeGameReadyViewModel(me: me, peer: peer))
         case .game(let matchPeer, let isNetwork):
-            if let myExplorer = players.first {
-                let me = LobbyExplorer(
+            if let myPlayer = players.first {
+                let me = PlayerInfo(
+                    id: myPlayer.id,
                     role: .me,
-                    displayName: myExplorer.nickname,
-                    avatar: CharacterAvatar.init(rawValue: myExplorer.character)
+                    displayName: myPlayer.nickname,
+                    avatar: CharacterAvatar.init(rawValue: myPlayer.character)
                     ?? .character1
                 )
                 let gameConfig = UserDefaultsList.Settings()
                 
                 GameView(
                     viewModel: viewModelFactory
-                        .makeGameViewModel(me: me, matchPeer: matchPeer, gameConfig: gameConfig, isNetwork: isNetwork),
+                        .makeGameViewModel(localPlayer: me, remotePlayer: matchPeer, gameConfig: gameConfig, isNetwork: isNetwork),
                     videoManager: viewModelFactory.makeVideoManager()
                 )
             }
@@ -85,9 +87,9 @@ struct RootView: View {
 extension RootView {
     private func checkUserStatus() {
         let hasCompletedPermission = UserDefaultsList.Permission.hasCompletedPermissionSetup
-        let hasPlayerProfile = !players.isEmpty
+        let hasPlayerInfo = !players.isEmpty
 
-        if hasPlayerProfile {
+        if hasPlayerInfo {
             router.setRoot(.lobby)
         } else if hasCompletedPermission {
             router.setRoot(.profileSetup)

--- a/iOS/App/Sources/Presentation/Shared/Models/PlayerInfo.swift
+++ b/iOS/App/Sources/Presentation/Shared/Models/PlayerInfo.swift
@@ -1,0 +1,43 @@
+//
+//  PlayerInfo.swift
+//  App
+//
+//  Created by sungkug_apple_developer_ac on 1/7/26.
+//
+
+import Foundation
+
+// MARK: - Player Role
+
+enum PlayerRole: Equatable {
+    case me
+    case peer
+}
+
+// MARK: - Player Info
+
+struct PlayerInfo: Identifiable, Equatable, Hashable {
+    let id: UUID
+    let role: PlayerRole
+    let displayName: String
+    let avatar: CharacterAvatar
+
+    /// 수신 감도/근접도: 0.0~1.0, 값이 클수록 내 위치에 더 가까움
+    /// - nil이면 아직 미측정/알 수 없음
+    /// - peer만 의미 있음 (me는 항상 중앙 고정)
+    var proximity: Double?
+
+    init(
+        id: UUID? = nil,
+        role: PlayerRole,
+        displayName: String,
+        avatar: CharacterAvatar,
+        proximity: Double? = nil
+    ) {
+        self.id = id ?? UUID()
+        self.role = role
+        self.displayName = displayName
+        self.avatar = avatar
+        self.proximity = proximity
+    }
+}

--- a/iOS/Modules/Games/Sources/GameplayManager.swift
+++ b/iOS/Modules/Games/Sources/GameplayManager.swift
@@ -43,7 +43,7 @@ public final class GameplayManager {
     public var state: GameState
     
     public let localPlayerID: UUID
-    public let otherPlayerIDs: [UUID]
+    public let remotePlayerIDs: [UUID]
     
     private var jumpRequestedPlayerIDs: Set<UUID> = []
 
@@ -82,12 +82,12 @@ public final class GameplayManager {
 
     public init(
         localPlayerID: UUID,
-        otherPlayerIDs: [UUID] = [],
+        remotePlayerIDs: [UUID] = [],
         endCondition: any GameEndCondition = TimeoutOrFinishEndCondition(limit: 60, targetPlatformIndex: 30)
     ) {
         self.localPlayerID = localPlayerID
-        self.otherPlayerIDs = otherPlayerIDs
-        self.state = GameState(localPlayerID: localPlayerID, otherPlayerIDs: otherPlayerIDs)
+        self.remotePlayerIDs = remotePlayerIDs
+        self.state = GameState(localPlayerID: localPlayerID, remotePlayerIDs: remotePlayerIDs)
                 
         self.gameEnd = GameEndTracker(condition: endCondition)
     }
@@ -300,7 +300,7 @@ extension GameplayManager {
     }
 
     public func startNewGame() {
-        state = GameState(localPlayerID: localPlayerID, otherPlayerIDs: otherPlayerIDs)
+        state = GameState(localPlayerID: localPlayerID, remotePlayerIDs: remotePlayerIDs)
         jumpRequestedPlayerIDs.removeAll(keepingCapacity: true)
         pendingRespawnPositionByPlayerID.removeAll(keepingCapacity: true)
 

--- a/iOS/Modules/Games/Sources/Model/GameState.swift
+++ b/iOS/Modules/Games/Sources/Model/GameState.swift
@@ -15,11 +15,11 @@ public struct GameState: Equatable, Sendable {
 
     public init(
         localPlayerID: UUID,
-        otherPlayerIDs: [UUID] = [],
+        remotePlayerIDs: [UUID] = [],
     ) {
         self.localPlayerID = localPlayerID
         var dict: [UUID: CharacterState] = [localPlayerID: CharacterState()]
-        for id in otherPlayerIDs where id != localPlayerID {
+        for id in remotePlayerIDs where id != localPlayerID {
             dict[id] = CharacterState()
         }
         self.characters = dict

--- a/iOS/Modules/NetworkKit/Sources/Interfaces/ClientManaging.swift
+++ b/iOS/Modules/NetworkKit/Sources/Interfaces/ClientManaging.swift
@@ -11,7 +11,7 @@ import Network
 public protocol ClientManaging {
     var onPermissionGranted: (() -> Void)? { get set }
     var onPermissionDeniedOrFailed: ((Error) -> Void)? { get set }
-    var onPeersUpdated: (([Peer]) -> Void)? { get set }
+    var onPeersUpdated: (([NetworkPeer]) -> Void)? { get set }
     var onDataReceived: ((Data, NWConnection) -> Void)? { get set }
 
     func startBrowsing()

--- a/iOS/Modules/NetworkKit/Sources/Interfaces/ConnectionSessionManaging.swift
+++ b/iOS/Modules/NetworkKit/Sources/Interfaces/ConnectionSessionManaging.swift
@@ -15,22 +15,22 @@ public protocol ConnectionSessionManaging: AnyObject {
 
     // MARK: - call back
 
-    var onInviteReceived: ((String) -> Void)? { get set }
-    var onInviteAccepted: ((String) -> Void)? { get set }
-    var onInviteDeclined: ((String) -> Void)? { get set }
-    var onInviteCancelled: ((String) -> Void)? { get set }
-    var onInputReceived: ((String, Data) -> Void)? { get set }
-    var onReadyStatusReceived: ((String) -> Void)? { get set }
-    var onVideoReceived: ((String, Data) -> Void)? { get set }
+    var onInviteReceived: ((UUID) -> Void)? { get set }
+    var onInviteAccepted: ((UUID) -> Void)? { get set }
+    var onInviteDeclined: ((UUID) -> Void)? { get set }
+    var onInviteCancelled: ((UUID) -> Void)? { get set }
+    var onInputReceived: ((UUID, Data) -> Void)? { get set }
+    var onReadyStatusReceived: ((UUID) -> Void)? { get set }
+    var onVideoReceived: ((UUID, Data) -> Void)? { get set }
 
     // MARK: - action
 
-    func sendInvite(to targetId: String)
-    func acceptInvite(from targetId: String)
-    func declineInvite(from targetId: String)
-    func cancelInvite(to targetId: String)
-    func sendInput<T: Codable>(_ data: T, to targetId: String?)
-    func sendReadyStatus(to targetId: String)
+    func sendInvite(to targetId: UUID)
+    func acceptInvite(from targetId: UUID)
+    func declineInvite(from targetId: UUID)
+    func cancelInvite(to targetId: UUID)
+    func sendInput<T: Codable>(_ data: T, to targetId: UUID?)
+    func sendReadyStatus(to targetId: UUID)
     func sendVideo(data: Data)
 }
 

--- a/iOS/Modules/NetworkKit/Sources/Interfaces/HostManaging.swift
+++ b/iOS/Modules/NetworkKit/Sources/Interfaces/HostManaging.swift
@@ -13,7 +13,7 @@ public protocol HostManaging {
     var onPermissionDeniedOrFailed: ((Error) -> Void)? { get set }
     var onDataReceived: ((Data, NWConnection) -> Void)? { get set }
 
-    func startHosting(nickName: String, status: PeerStatus)
+    func startHosting(nickName: String, status: PeerStatus, sessionId: UUID)
     func stopHosting()
     func sendData(_ data: Data, to connection: NWConnection)
 }

--- a/iOS/Modules/NetworkKit/Sources/Interfaces/NetworkSessionManaging.swift
+++ b/iOS/Modules/NetworkKit/Sources/Interfaces/NetworkSessionManaging.swift
@@ -13,7 +13,7 @@ public enum LocalNetworkError: Error {
 }
 
 public protocol NetworkSessionManaging: ConnectionSessionManaging {
-    var nearbyPlayer: [Peer] { get }
+    var nearbyPlayer: [NetworkPeer] { get }
     var onPermissionResult: ((Result<Void, LocalNetworkError>) -> Void)? { get set }
-    var onPeersUpdated: (([Peer]) -> Void)? { get set }
+    var onPeersUpdated: (([NetworkPeer]) -> Void)? { get set }
 }

--- a/iOS/Modules/NetworkKit/Sources/Interfaces/WebSocketSessionManaging.swift
+++ b/iOS/Modules/NetworkKit/Sources/Interfaces/WebSocketSessionManaging.swift
@@ -14,6 +14,6 @@ public protocol WebSocketSessionManaging: ConnectionSessionManaging {
     
     var onPlayersUpdated: (([WebSocketPlayer]) -> Void)? { get set }
     var onPlayerJoined: ((WebSocketPlayer) -> Void)? { get set }
-    var onPlayerLeft: ((String) -> Void)? { get set }
+    var onPlayerLeft: ((UUID) -> Void)? { get set }
     var onConnectionStateChanged: ((Bool) -> Void)? { get set }
 }

--- a/iOS/Modules/NetworkKit/Sources/P2P/ClientManager.swift
+++ b/iOS/Modules/NetworkKit/Sources/P2P/ClientManager.swift
@@ -25,7 +25,7 @@ final class ClientManager: ClientManaging {
 
     var onPermissionGranted: (() -> Void)?
     var onPermissionDeniedOrFailed: ((Error) -> Void)?
-    var onPeersUpdated: (([Peer]) -> Void)?
+    var onPeersUpdated: (([NetworkPeer]) -> Void)?
     var onDataReceived: ((Data, NWConnection) -> Void)?
 
     // MARK: - Initialization
@@ -45,7 +45,7 @@ final class ClientManager: ClientManaging {
         let parameters = NWParameters()
         parameters.includePeerToPeer = true
 
-        browser = NWBrowser(for: .bonjour(type: serviceType, domain: nil), using: parameters)
+        browser = NWBrowser(for: .bonjourWithTXTRecord(type: serviceType, domain: nil), using: parameters)
         
         browser?.browseResultsChangedHandler = { [weak self] results, changes in
             self?.handleBrowseResultsChanged(results: results, changes: changes)
@@ -158,13 +158,15 @@ final class ClientManager: ClientManaging {
     private func handleBrowseResultsChanged(results: Set<NWBrowser.Result>, changes: Set<NWBrowser.Result.Change>) {
         logger.info("탐색 결과 변경: \(results.count) 명의 동료 찾음")
 
-        let peers = results.compactMap { result -> Peer? in
+        let peers = results.compactMap { result -> NetworkPeer? in
             // 서비스 이름 추출
             guard case .service(let name, _, _, _) = result.endpoint else {
                 return nil
             }
 
             var status: PeerStatus = .available
+            var nickname = name
+            var sessionId: UUID?
 
             if case .bonjour(let txtRecord) = result.metadata {
                 if let statusString = txtRecord["status"],
@@ -172,10 +174,19 @@ final class ClientManager: ClientManaging {
                     status = parsedStatus
                     logger.info("Parsed peer \(name) with status: \(status.rawValue)")
                 }
+                if let nicknameString = txtRecord["nickname"] {
+                    nickname = nicknameString
+                }
+                if let sessionIdString = txtRecord["sessionId"] {
+                    sessionId = UUID(uuidString: sessionIdString)
+                }
             }
 
-            return Peer(
-                name: name,
+            guard let sessionId else { return nil }
+
+            return NetworkPeer(
+                sessionId: sessionId,
+                name: nickname,
                 status: status,
                 endpoint: result.endpoint,
                 latency: nil                    // 탐색 직후부터 latency를 계산할 수 없으므로 초기값 nil

--- a/iOS/Modules/NetworkKit/Sources/P2P/HostManager.swift
+++ b/iOS/Modules/NetworkKit/Sources/P2P/HostManager.swift
@@ -38,10 +38,14 @@ final class HostManager: HostManaging {
 
     // MARK: - Public Methods
 
-    func startHosting(nickName: String, status: PeerStatus) {
+    func startHosting(nickName: String, status: PeerStatus, sessionId: UUID) {
         logger.info("호스팅 시작 nickName: \(nickName), status: \(status.rawValue)")
 
-        let txtRecord = NWTXTRecord(["status": status.rawValue])
+        let txtRecord = NWTXTRecord([
+            "status": status.rawValue,
+            "nickname": nickName,
+            "sessionId": sessionId.uuidString
+        ])
         let parameters = NWParameters.tcp
         parameters.includePeerToPeer = true
         

--- a/iOS/Modules/NetworkKit/Sources/P2P/NetworkPeer.swift
+++ b/iOS/Modules/NetworkKit/Sources/P2P/NetworkPeer.swift
@@ -1,10 +1,11 @@
 //
-//  Peer.swift
+//  NetworkPeer.swift
 //  NetworkKit
 //
 //  Created by 강윤서 on 1/6/26.
 //
 
+import Foundation
 import Network
 
 public enum PeerStatus: String {
@@ -12,8 +13,9 @@ public enum PeerStatus: String {
     case busy
 }
 
-public struct Peer: Identifiable, Equatable {
+public struct NetworkPeer: Identifiable, Equatable {
     public var id: String { endpoint.debugDescription }
+    public let sessionId: UUID
     public let name: String
     public let status: PeerStatus
     public let endpoint: NWEndpoint

--- a/iOS/Modules/NetworkKit/Sources/P2P/NetworkSessionManager.swift
+++ b/iOS/Modules/NetworkKit/Sources/P2P/NetworkSessionManager.swift
@@ -22,29 +22,31 @@ public final class NetworkSessionManager: NetworkSessionManaging {
     private var hostGranted: Bool? = nil
     private var clientGranted: Bool? = nil
     private var myNickname: String?
-    public var nearbyPlayer: [Peer] = []
+    public var nearbyPlayer: [NetworkPeer] = []
+    private var localSessionId: UUID = UUID()
 
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
 
-    private var pendingInviteConnections: [String: NWConnection] = [:]
+    private var pendingInviteConnections: [UUID: NWConnection] = [:]
     private var activeGameConnection: NWConnection?
-    private var lastPingTimestamps: [String: Date] = [:]
+    private var lastPingTimestamps: [UUID: Date] = [:]
     private var pingTimer: Timer?
+    private var peerById: [UUID: NetworkPeer] = [:]
 
     private let logger = Logger(subsystem: "com.cosmicadventure.networkkit", category: "NetworkSessionManager")
 
     // MARK: - Callbacks
 
     public var onPermissionResult: ((Result<Void, LocalNetworkError>) -> Void)?
-    public var onInviteReceived: ((String) -> Void)?
-    public var onInviteAccepted: ((String) -> Void)?
-    public var onInviteDeclined: ((String) -> Void)?
-    public var onInviteCancelled: ((String) -> Void)?
-    public var onInputReceived: ((String, Data) -> Void)?
-    public var onPeersUpdated: (([Peer]) -> Void)?
-    public var onReadyStatusReceived: ((String) -> Void)?
-    public var onVideoReceived: ((String, Data) -> Void)?
+    public var onInviteReceived: ((UUID) -> Void)?
+    public var onInviteAccepted: ((UUID) -> Void)?
+    public var onInviteDeclined: ((UUID) -> Void)?
+    public var onInviteCancelled: ((UUID) -> Void)?
+    public var onInputReceived: ((UUID, Data) -> Void)?
+    public var onPeersUpdated: (([NetworkPeer]) -> Void)?
+    public var onReadyStatusReceived: ((UUID) -> Void)?
+    public var onVideoReceived: ((UUID, Data) -> Void)?
 
     // MARK: - Initialization
 
@@ -72,8 +74,9 @@ public final class NetworkSessionManager: NetworkSessionManaging {
          logger.info("P2P 탐색 시작")
 
          myNickname = nickname
+         localSessionId = UUID()
 
-         host.startHosting(nickName: nickname, status: .available)
+         host.startHosting(nickName: nickname, status: .available, sessionId: localSessionId)
          client.startBrowsing()
          startPingTimer()
      }
@@ -89,6 +92,7 @@ public final class NetworkSessionManager: NetworkSessionManaging {
          stopPingTimer()
 
          nearbyPlayer.removeAll()
+         peerById.removeAll()
          myNickname = nil
 
          hostGranted = nil
@@ -97,35 +101,35 @@ public final class NetworkSessionManager: NetworkSessionManaging {
          onPermissionResult = nil
      }
 
-    public func sendInvite(to peerName: String) {
-        guard let targetPeer = nearbyPlayer.first(where: { $0.name == peerName }) else { return }
-        let packet = NetworkPacket(type: .invite, senderIdentifier: myNickname ?? "Unknown")
+    public func sendInvite(to targetId: UUID) {
+        guard let targetPeer = peerById[targetId] else { return }
+        let packet = NetworkPacket(type: .invite, senderIdentifier: localSessionId.uuidString)
 
         sendToPeer(to: targetPeer, packet: packet)
     }
 
-    public func cancelInvite(to peerName: String) {
-        guard let targetPeer = nearbyPlayer.first(where: { $0.name == peerName }) else { return }
-        let packet = NetworkPacket(type: .inviteCancel, senderIdentifier: myNickname ?? "Unknown")
+    public func cancelInvite(to targetId: UUID) {
+        guard let targetPeer = peerById[targetId] else { return }
+        let packet = NetworkPacket(type: .inviteCancel, senderIdentifier: localSessionId.uuidString)
 
         sendToPeer(to: targetPeer, packet: packet)
     }
 
-    public func acceptInvite(from peerName: String) {
-        let packet = NetworkPacket(type: .inviteAccept, senderIdentifier: myNickname ?? "Unknown")
-        replyToPeer(to: peerName, packet: packet)
+    public func acceptInvite(from targetId: UUID) {
+        let packet = NetworkPacket(type: .inviteAccept, senderIdentifier: localSessionId.uuidString)
+        replyToPeer(to: targetId, packet: packet)
     }
 
-    public func declineInvite(from peerName: String) {
-        let packet = NetworkPacket(type: .inviteDecline, senderIdentifier: myNickname ?? "Unknown")
-        replyToPeer(to: peerName, packet: packet)
+    public func declineInvite(from targetId: UUID) {
+        let packet = NetworkPacket(type: .inviteDecline, senderIdentifier: localSessionId.uuidString)
+        replyToPeer(to: targetId, packet: packet)
     }
 
-    public func sendInput<T: Codable>(_ data: T, to targetId: String?) {
+    public func sendInput<T: Codable>(_ data: T, to targetId: UUID?) {
         guard let payload = try? encoder.encode(data) else { return }
         let packet = NetworkPacket(
             type: .input,
-            senderIdentifier: myNickname ?? "Unknown",
+            senderIdentifier: localSessionId.uuidString,
             payload: payload
         )
         guard let encodedPacket = try? encoder.encode(packet) else { return }
@@ -139,9 +143,9 @@ public final class NetworkSessionManager: NetworkSessionManaging {
         }
     }
 
-    public func sendReadyStatus(to peerName: String) {
-        guard let targetPeer = nearbyPlayer.first(where: { $0.name == peerName }) else { return }
-        let packet = NetworkPacket(type: .gameReady, senderIdentifier: myNickname ?? "Unknown")
+    public func sendReadyStatus(to targetId: UUID) {
+        guard let targetPeer = peerById[targetId] else { return }
+        let packet = NetworkPacket(type: .gameReady, senderIdentifier: localSessionId.uuidString)
 
         sendToPeer(to: targetPeer, packet: packet)
     }
@@ -149,7 +153,7 @@ public final class NetworkSessionManager: NetworkSessionManaging {
     public func sendVideo(data: Data) {
         let packet = NetworkPacket(
             type: .videoFrame,
-            senderIdentifier: myNickname ?? "Unknown",
+            senderIdentifier: localSessionId.uuidString,
             payload: data
         )
 
@@ -195,8 +199,8 @@ public final class NetworkSessionManager: NetworkSessionManaging {
 
         client.onPeersUpdated = { [weak self] peers in
             guard let self else { return }
-            print("📡 [NetworkSessionManager] 원본 피어 발견: \(peers.count)명")
-            let filteredPeers = peers.filter { $0.name != self.myNickname }
+            logger.debug("📡 [NetworkSessionManager] 원본 피어 발견: \(peers.count)명")
+            let filteredPeers = peers.filter { $0.sessionId != self.localSessionId }
 
             // UI에 표시될 순서대로 정렬(연결 가능한 순서대로 처리)
             // 추후 변경 가능성 존재
@@ -209,8 +213,9 @@ public final class NetworkSessionManager: NetworkSessionManaging {
                     return peer1.name < peer2.name
                 }
             }
+            self.peerById = Dictionary(uniqueKeysWithValues: self.nearbyPlayer.map { ($0.sessionId, $0) })
             self.onPeersUpdated?(self.nearbyPlayer)
-            print("📡 [NetworkSessionManager] 필터링 후 피어: \(self.nearbyPlayer.count)명")
+            logger.debug("📡 [NetworkSessionManager] 필터링 후 피어: \(self.nearbyPlayer.count)명")
         }
 
         client.onDataReceived = { [weak self] data, connection in
@@ -256,8 +261,8 @@ public final class NetworkSessionManager: NetworkSessionManaging {
 
     private func sendPingsToAll() {
         for player in nearbyPlayer {
-            let packet = NetworkPacket(type: .ping, senderIdentifier: myNickname ?? "Unknown")
-            lastPingTimestamps[player.name] = Date()
+            let packet = NetworkPacket(type: .ping, senderIdentifier: localSessionId.uuidString)
+            lastPingTimestamps[player.sessionId] = Date()
             sendToPeer(to: player, packet: packet)
         }
     }
@@ -265,8 +270,10 @@ public final class NetworkSessionManager: NetworkSessionManaging {
     private func handleReceivedData(_ data: Data, from connection: NWConnection) {
         guard let packet = try? decoder.decode(NetworkPacket.self, from: data) else { return }
 
+        guard let senderId = UUID(uuidString: packet.senderIdentifier) else { return }
+
         if packet.type == .invite {
-            self.pendingInviteConnections[packet.senderIdentifier] = connection
+            self.pendingInviteConnections[senderId] = connection
         }
 
         DispatchQueue.main.async { [weak self] in
@@ -274,56 +281,56 @@ public final class NetworkSessionManager: NetworkSessionManaging {
 
             switch packet.type {
             case .ping:
-                let pongPacket = NetworkPacket(type: .pong, senderIdentifier: myNickname ?? "Unknown")
+                let pongPacket = NetworkPacket(type: .pong, senderIdentifier: localSessionId.uuidString)
                 guard let encodedPong = try? self.encoder.encode(pongPacket) else { return }
                 host.sendData(encodedPong, to: connection)
 
             case .pong:
-                if let sendDate = lastPingTimestamps[packet.senderIdentifier] {
+                if let sendDate = lastPingTimestamps[senderId] {
                     let latency = Date().timeIntervalSince(sendDate) * 1000.0
-                    updatePeerLatency(name: packet.senderIdentifier, latency: latency)
-                    lastPingTimestamps.removeValue(forKey: packet.senderIdentifier)
+                    updatePeerLatency(sessionId: senderId, latency: latency)
+                    lastPingTimestamps.removeValue(forKey: senderId)
                 }
 
             case .invite:
-                onInviteReceived?(packet.senderIdentifier)
+                onInviteReceived?(senderId)
 
             case .inviteAccept:
                 activeGameConnection = connection
-                pendingInviteConnections.removeValue(forKey: packet.senderIdentifier)
-                onInviteAccepted?(packet.senderIdentifier)
+                pendingInviteConnections.removeValue(forKey: senderId)
+                onInviteAccepted?(senderId)
 
             case .inviteDecline:
-                onInviteDeclined?(packet.senderIdentifier)
+                onInviteDeclined?(senderId)
 
             case .inviteCancel:
-                onInviteCancelled?(packet.senderIdentifier)
+                onInviteCancelled?(senderId)
 
             case .input:
                 if let payload = packet.payload {
-                    onInputReceived?(packet.senderIdentifier, payload)
+                    onInputReceived?(senderId, payload)
                 }
 
             case .gameReady:
-                onReadyStatusReceived?(packet.senderIdentifier)
+                onReadyStatusReceived?(senderId)
 
             case .videoFrame:
                 if let payload = packet.payload {
-                    onVideoReceived?(packet.senderIdentifier, payload)
+                    onVideoReceived?(senderId, payload)
                 }
             }
         }
     }
 
     /// ping/pong 결과에 따라 latency 상태 업데이트
-    private func updatePeerLatency(name: String, latency: Double) {
-        if let index = nearbyPlayer.firstIndex(where: { $0.name == name }) {
+    private func updatePeerLatency(sessionId: UUID, latency: Double) {
+        if let index = nearbyPlayer.firstIndex(where: { $0.sessionId == sessionId }) {
             nearbyPlayer[index].latency = latency
             onPeersUpdated?(nearbyPlayer)
         }
     }
 
-    private func sendToPeer(to peer: Peer, packet: NetworkPacket) {
+    private func sendToPeer(to peer: NetworkPeer, packet: NetworkPacket) {
         guard let data = try? encoder.encode(packet) else { return }
 
         Task {
@@ -336,8 +343,8 @@ public final class NetworkSessionManager: NetworkSessionManaging {
         }
     }
 
-    private func replyToPeer(to targetName: String, packet: NetworkPacket) {
-        guard let connection = self.pendingInviteConnections[targetName] else { return }
+    private func replyToPeer(to targetId: UUID, packet: NetworkPacket) {
+        guard let connection = self.pendingInviteConnections[targetId] else { return }
 
         guard let data = try? encoder.encode(packet) else { return }
         host.sendData(data, to: connection)
@@ -352,6 +359,6 @@ public final class NetworkSessionManager: NetworkSessionManaging {
             self.activeGameConnection = connection
         }
 
-        self.pendingInviteConnections.removeValue(forKey: targetName)
+        self.pendingInviteConnections.removeValue(forKey: targetId)
     }
 }

--- a/iOS/Modules/NetworkKit/Sources/Utils/DeterministicUUID.swift
+++ b/iOS/Modules/NetworkKit/Sources/Utils/DeterministicUUID.swift
@@ -1,0 +1,26 @@
+//
+//  DeterministicUUID.swift
+//  NetworkKit
+//
+//  Created by sungkug_apple_developer_ac on 1/26/26.
+//
+
+import CryptoKit
+import Foundation
+
+public enum DeterministicUUID {
+    public static func fromString(_ value: String, namespace: String) -> UUID {
+        let data = Data((namespace + ":" + value).utf8)
+        let hash = SHA256.hash(data: data)
+        var bytes = Array(hash.prefix(16))
+        // RFC 4122 variant + version 5 (namespace-based) style
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+}

--- a/iOS/Modules/NetworkKit/Sources/WebSocket/WebSocketPlayer.swift
+++ b/iOS/Modules/NetworkKit/Sources/WebSocket/WebSocketPlayer.swift
@@ -5,13 +5,17 @@
 //  Created by 강윤서 on 1/16/26.
 //
 
+import Foundation
+
 public struct WebSocketPlayer: Identifiable, Equatable {
-    public let id: String
+    public let id: UUID
+    public let sessionId: String
     public let nickname: String
     public var latency: Double?
     
-    public init(id: String, nickname: String, latency: Double? = nil) {
+    public init(id: UUID, sessionId: String, nickname: String, latency: Double? = nil) {
         self.id = id
+        self.sessionId = sessionId
         self.nickname = nickname
         self.latency = latency
     }

--- a/iOS/Modules/NetworkKit/Sources/WebSocket/WebSocketSessionManager.swift
+++ b/iOS/Modules/NetworkKit/Sources/WebSocket/WebSocketSessionManager.swift
@@ -28,15 +28,15 @@ public final class WebSocketSessionManager: WebSocketSessionManaging {
     
     public var onPlayersUpdated: (([WebSocketPlayer]) -> Void)?
     public var onPlayerJoined: ((WebSocketPlayer) -> Void)?
-    public var onPlayerLeft: ((String) -> Void)?
-    public var onInviteReceived: ((String) -> Void)?
-    public var onInviteAccepted: ((String) -> Void)?
-    public var onInviteDeclined: ((String) -> Void)?
-    public var onInviteCancelled: ((String) -> Void)?
-    public var onInputReceived: ((String, Data) -> Void)?
+    public var onPlayerLeft: ((UUID) -> Void)?
+    public var onInviteReceived: ((UUID) -> Void)?
+    public var onInviteAccepted: ((UUID) -> Void)?
+    public var onInviteDeclined: ((UUID) -> Void)?
+    public var onInviteCancelled: ((UUID) -> Void)?
+    public var onInputReceived: ((UUID, Data) -> Void)?
     public var onConnectionStateChanged: ((Bool) -> Void)?
-    public var onReadyStatusReceived: ((String) -> Void)?
-    public var onVideoReceived: ((String, Data) -> Void)?
+    public var onReadyStatusReceived: ((UUID) -> Void)?
+    public var onVideoReceived: ((UUID, Data) -> Void)?
 
     // MARK: - Initialization
     
@@ -69,31 +69,36 @@ public final class WebSocketSessionManager: WebSocketSessionManaging {
         mySessionId = nil
     }
     
-    public func sendInvite(to playerId: String) {
-        service.sendInvite(to: playerId)
+    public func sendInvite(to targetId: UUID) {
+        guard let sessionId = sessionId(forPlayerId: targetId) else { return }
+        service.sendInvite(to: sessionId)
     }
     
-    public func acceptInvite(from playerId: String) {
-        service.acceptInvite(from: playerId)
+    public func acceptInvite(from targetId: UUID) {
+        guard let sessionId = sessionId(forPlayerId: targetId) else { return }
+        service.acceptInvite(from: sessionId)
     }
     
-    public func declineInvite(from playerId: String) {
-        service.declineInvite(from: playerId)
+    public func declineInvite(from targetId: UUID) {
+        guard let sessionId = sessionId(forPlayerId: targetId) else { return }
+        service.declineInvite(from: sessionId)
     }
     
-    public func cancelInvite(to playerId: String) {
-        service.cancelInvite(to: playerId)
+    public func cancelInvite(to targetId: UUID) {
+        guard let sessionId = sessionId(forPlayerId: targetId) else { return }
+        service.cancelInvite(to: sessionId)
     }
     
-    public func sendInput<T: Codable>(_ data: T, to playerId: String?) {
-        guard let playerId,
-              let targetId = sessionId(forNickname: playerId) else { return }
+    public func sendInput<T: Codable>(_ data: T, to targetId: UUID?) {
+        guard let targetId,
+              let sessionId = sessionId(forPlayerId: targetId) else { return }
 
-        service.sendInput(data, to: targetId)
+        service.sendInput(data, to: sessionId)
     }
 
-    public func sendReadyStatus(to playerId: String) {
-        service.sendReadyStatus(to: playerId)
+    public func sendReadyStatus(to targetId: UUID) {
+        guard let sessionId = sessionId(forPlayerId: targetId) else { return }
+        service.sendReadyStatus(to: sessionId)
     }
 
     public func sendVideo(data: Data) {
@@ -149,26 +154,26 @@ public final class WebSocketSessionManager: WebSocketSessionManaging {
             handlePlayerLeft(message.senderId)
             
         case .invite:
-            onInviteReceived?(message.senderId)
+            onInviteReceived?(playerId(forSenderId: message.senderId))
             
         case .inviteAccept:
-            onInviteAccepted?(message.senderId)
+            onInviteAccepted?(playerId(forSenderId: message.senderId))
             
         case .inviteDecline:
-            onInviteDeclined?(message.senderId)
+            onInviteDeclined?(playerId(forSenderId: message.senderId))
             
         case .inviteCancel:
-            onInviteCancelled?(message.senderId)
+            onInviteCancelled?(playerId(forSenderId: message.senderId))
             
         case .input:
             if let payloadString = message.payload,
                let payloadData = payloadString.data(using: .utf8) {
 
-                onInputReceived?(nickname(forSessionId: message.senderId) ?? "", payloadData)
+                onInputReceived?(playerId(forSenderId: message.senderId), payloadData)
             }
 
         case .gameReady:
-            onReadyStatusReceived?(message.senderId)
+            onReadyStatusReceived?(playerId(forSenderId: message.senderId))
 
         default:
             break
@@ -192,7 +197,8 @@ public final class WebSocketSessionManager: WebSocketSessionManaging {
 
             if sessionId == mySessionId { continue }
 
-            newPlayers.append(WebSocketPlayer(id: sessionId, nickname: nickname, latency: latency))
+            let playerId = playerId(forSenderId: sessionId)
+            newPlayers.append(WebSocketPlayer(id: playerId, sessionId: sessionId, nickname: nickname, latency: latency))
         }
 
         players = newPlayers
@@ -207,30 +213,34 @@ public final class WebSocketSessionManager: WebSocketSessionManaging {
         let nickname = String(parts[1])
         let latency = parts.count > 2 ? Double(parts[2]) : nil
 
-        guard !players.contains(where: { $0.id == sessionId }) else {
+        let playerId = playerId(forSenderId: sessionId)
+        guard !players.contains(where: { $0.sessionId == sessionId }) else {
             return
         }
 
-        let player = WebSocketPlayer(id: sessionId, nickname: nickname, latency: latency)
+        let player = WebSocketPlayer(id: playerId, sessionId: sessionId, nickname: nickname, latency: latency)
         players.append(player)
         onPlayerJoined?(player)
     }
     
-    private func handlePlayerLeft(_ sessionId: String) {
-        players.removeAll { $0.id == sessionId }
-        onPlayerLeft?(sessionId)
+    private func handlePlayerLeft(_ senderId: String) {
+        let playerId = playerId(forSenderId: senderId)
+        players.removeAll { $0.sessionId == senderId || $0.nickname == senderId }
+        onPlayerLeft?(playerId)
     }
 }
 
 
-// TODO: 모델 구조랑 통신구조 p2p/webSocket 통일하면서 로직개선
+// TODO: players 목록 동기화 전 메시지 수신 처리 개선 (임시 UUID fallback 제거)
 extension WebSocketSessionManager {
-    private func nickname(forSessionId sessionId: String) -> String? {
-        players.first(where: { $0.id == sessionId })?.nickname
+    private func playerId(forSenderId senderId: String) -> UUID {
+        if let cached = players.first(where: { $0.sessionId == senderId })?.id {
+            return cached
+        }
+        return DeterministicUUID.fromString(senderId, namespace: "ws-sender")
     }
 
-    private func sessionId(forNickname nickname: String) -> String? {
-        players.first(where: { $0.nickname == nickname })?.id
+    private func sessionId(forPlayerId playerId: UUID) -> String? {
+        players.first(where: { $0.id == playerId })?.sessionId
     }
-
 }


### PR DESCRIPTION
## 요약

플레이어 식별자를 닉네임 기반에서 UUID 기반으로 전환하면서, 멀티플레이(P2P/WebSocket) 전반에서 동일한 기준으로 매칭되도록 모델/콜백 흐름을 정리했습니다.  표시용 닉네임은 유지하되 내부 식별자와 분리하여 충돌 가능성을 제거했습니다.

### 작업 목록

- [x] `LobbyExplorer` → `PlayerInfo`로 리네이밍 및 공용 도메인 모델화
- [x] 플레이어 매칭/라우팅 키를 `nickname(String)` → `UUID` 기준으로 통일
- [x] P2P / WebSocket 모두 동일한 `playerId(UUID)` 흐름으로 플레이어 연결 관리
- [x] 네트워크 객체(`NetworkPeer`, `WebSocketPlayer`)에 sessionId 추가로 연결 추적 강화
- [x] bonjour 브라우징 방식을 TXT Record 수신 가능한 방식으로 보완

## 작업 내용

### 1) 공용 도메인 모델로 통일

- LobbyExplorer → PlayerInfo로 리네이밍/정리
- 역할(role), 표시명(displayName), 아바타(avatar) 등 표시/UI용 정보는 PlayerInfo에 유지
- 네트워크/게임 로직에서 참조하는 식별자는 PlayerInfo.id(UUID) 로 통일

### 2) 라우팅 키를 UUID로 전환 
- 송수신/플레이어 매칭 기준을 nickname(String) → playerId(UUID) 로 변경
- P2P / WebSocket 양쪽에서 동일한 playerId 흐름을 사용하도록 정리

### 3) 연결 추적 강화를 위한 sessionId 도입
- 네트워크 객체(NetworkPeer, WebSocketPlayer)에 sessionId를 추가해 연결 단위를 추적 가능하게 했습니다.
- “플레이어(논리)”와 “연결(물리/세션)”을 분리해서 추후 재접속/끊김 처리에서 확장 가능하도록 기반을 마련했습니다.

### 4) Bonjour 브라우징 보완
- bonjour 브라우징을 TXT Record 수신 가능한 방식으로 보완하여, 브로드캐스트/식별 정보 전달의 안정성을 높였습니다.
- TXT Record를 통해 host의 status와 닉네임, 세션id 를 보내어 관리할 수 있도록 하였습니다

### 5) 상태 초기화 로직 연결
- 로비뷰에서 전환되었을 때 게임 matchStatus 값 초기화가 이루어지지 않아 stopNetworkExploration 에서 초기화가 진행되도록 하였습니다

### 동작 확인

**초대 로직(p2p)**

https://github.com/user-attachments/assets/284dbf32-f455-487a-badd-adfdceb506c0

**초대 로직(websocket)**

https://github.com/user-attachments/assets/c8fd4dec-e1ca-46a7-ae72-2d8ed46aaea4

**게임 플레이(혼자모드)**

https://github.com/user-attachments/assets/48742fdf-b6b9-42f0-9bef-0558bfab0944

**게임 플레이(p2p)**

https://github.com/user-attachments/assets/996d6650-6af3-495d-89ed-599e117c3d77

**게임 플레이(websocket)**

https://github.com/user-attachments/assets/01e08dfd-1156-4b7e-865a-b41945fff384


closes DEV-62
