### PR TITLE
[DEV-107] 세로모드 강제 추가 및 폰트 미적용 에러 해결

### DIFF
--- a/iOS/App/Project.swift
+++ b/iOS/App/Project.swift
@@ -33,31 +33,35 @@ let project = Project(
                 "NSAppTransportSecurity": .dictionary([
                     "NSAllowsArbitraryLoads": .boolean(true)
                 ]),
-                "API_BASE_URL": "$(API_BASE_URL)",
-                "UIAppFonts": [
-                  "Fonts/Pretendard-Thin.otf",
-                  "Fonts/Pretendard-ExtraLight.otf",
-                  "Fonts/Pretendard-Light.otf",
-                  "Fonts/Pretendard-Regular.otf",
-                  "Fonts/Pretendard-Medium.otf",
-                  "Fonts/Pretendard-SemiBold.otf",
-                  "Fonts/Pretendard-Bold.otf",
-                  "Fonts/Pretendard-ExtraBold.otf",
-                  "Fonts/Pretendard-Black.otf",
-                ],
-                "CFBundleDisplayName": "CosmicAdventure",
-                "UISupportedInterfaceOrientations": [
-                  "UIInterfaceOrientationPortrait"
-                ],
-                "UISupportedInterfaceOrientations~ipad": [
-                  "UIInterfaceOrientationPortrait"
-                ]
+                "API_BASE_URL": .string("$(API_BASE_URL)"),
+
+                "UIAppFonts": .array([
+                    .string("Pretendard-Thin.otf"),
+                    .string("Pretendard-ExtraLight.otf"),
+                    .string("Pretendard-Light.otf"),
+                    .string("Pretendard-Regular.otf"),
+                    .string("Pretendard-Medium.otf"),
+                    .string("Pretendard-SemiBold.otf"),
+                    .string("Pretendard-Bold.otf"),
+                    .string("Pretendard-ExtraBold.otf"),
+                    .string("Pretendard-Black.otf"),
+                ]),
+
+                "CFBundleDisplayName": .string("CosmicAdventure"),
+
+                "UISupportedInterfaceOrientations": .array([
+                    .string("UIInterfaceOrientationPortrait"),
+                ]),
+
+                "UISupportedInterfaceOrientations~ipad": .array([
+                    .string("UIInterfaceOrientationPortrait"),
+                ])
             ]),
             sources: [
                 "Sources/**"
             ],
             resources: [
-                "Resources/**"
+                "Resources/**",
             ],
             dependencies: [
                 .project(target: "Games", path: "../Modules/Games"),


### PR DESCRIPTION
## 요약

세로모드 강제 추가

### 작업 목록

- [x] 세로모드 강제 추가
- [x] 폰트 미적용 에러 해결

## 작업 내용

변경 사항: iPad 세로 모드 강제 (UISupportedInterfaceOrientations~ipad)
- iPhone과 iPad의 화면 회전 정책이 달라질 수 있어, iPad에서만 적용되는 방향 설정 키인 UISupportedInterfaceOrientations~ipad를 추가했습니다.
- UISupportedInterfaceOrientations는 기본(주로 iPhone 포함) 설정을 담당하고, ~ipad 키는 iPad에서 해당 값을 오버라이드합니다.
- 이를 통해 iPad에서도 Portrait만 허용되도록 명시해, 기기별 기본 회전 정책 차이로 인한 예기치 않은 가로 회전을 방지했습니다.


closes DEV-107
closes DEV-110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced Portrait-only orientation on iPhone and iPad for consistent display.
  * Updated app configuration entries: ensured app display name is set to "CosmicAdventure" and stabilized bundled font declarations.
  * Minor manifest formatting adjustments for cleaner configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->