### PR TITLE
[DEV-87] ClientManager의 connection 상태 처리 간소화

### DIFF
--- a/iOS/Modules/NetworkKit/Sources/P2P/ClientManager.swift
+++ b/iOS/Modules/NetworkKit/Sources/P2P/ClientManager.swift
@@ -71,12 +71,11 @@ final class ClientManager: ClientManaging {
     func connectToHost(endpoint: NWEndpoint) async throws {
         if let existingConnection = connections[endpoint] {
             switch existingConnection.state {
-            case .ready:     // 이미 연결이 완료된 상태면 재사용
+            case .ready:
                 return
-            case .preparing, .setup:    // 이미 연결 시도 중이면 상태가 변할 때까지 대기
-                try await waitForReady(connection: existingConnection)
-                return
-            default:        // 실패했거나 끊어진 상태면 새로 연결하기 위해 정리
+            case .preparing, .setup:
+                return  // 이미 연결 시도 중이면 그냥 반환 (기존 receiveData가 동작 중)
+            default:
                 existingConnection.cancel()
                 connections.removeValue(forKey: endpoint)
             }
@@ -84,36 +83,26 @@ final class ClientManager: ClientManaging {
 
         let parameters = NWParameters.tcp
         parameters.includePeerToPeer = true
-        
+
         let connection = NWConnection(to: endpoint, using: parameters)
         self.connections[endpoint] = connection
 
-        connection.start(queue: self.networkQueue)
-
-        try await waitForReady(connection: connection)
-        
-        self.logger.info("호스트에 연결 성공")
-        self.receiveData(from: connection)
-    }
-
-    private func waitForReady(connection: NWConnection) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            connection.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    connection.stateUpdateHandler = nil
-                    continuation.resume()
-                case .failed(let error):
-                    connection.stateUpdateHandler = nil
-                    continuation.resume(throwing: error)
-                case .cancelled:
-                    connection.stateUpdateHandler = nil
-                    continuation.resume(throwing: NWError.posix(.ECANCELED))
-                default:
-                    break
-                }
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                self.receiveData(from: connection)
+            case .failed(let error):
+                self.logger.error("연결 실패: \(error.localizedDescription)")
+                self.removeConnection(connection)
+            case .cancelled:
+                self.removeConnection(connection)
+            default:
+                self.logger.info("연결 상태: \(String(describing: state))")
             }
         }
+
+        connection.start(queue: self.networkQueue)
     }
 
     func sendData(_ data: Data, to endpoint: NWEndpoint) {


### PR DESCRIPTION
## 요약
- ClientManager의 연결 상태 처리 로직 간소화
- `stateUpdateHandler`를 `start()` 전에 설정하여 MISUSE 에러 방지
- `waitForReady` continuation 로직 제거

### 작업 목록
- [x] `connectToHost()` 내에서 handler 설정 후 start()를 호출하도록 순서 변경
- [x] `waitForReady()` 함수 삭제
- [x] ready 상태 도달 시 `receiveData()` 자동 호출

## 작업 내용
기존에는 connection이 ready 상태가 아니면 send()가 무시될 것으로 예상하여 waitForReady를 구현했으나, NWConnection은 내부적으로 큐잉 처리를 하므로 명시적인 ready 대기가 불필요하다는 것을 확인했습니다. [WWDC 참고(20분 쯤)](https://developer.apple.com/videos/play/wwdc2018/715/)

### 기존 코드의 MISUSE 에러 원인
`stateUpdateHandler`는 단일 클로저이므로, 여러 작업이 동시에 같은 connection에 대해 `waitForReady`를 호출하면 handler가 덮어씌워지는 문제가 발생했습니다.

**에러 케이스**
1. `ping` → `connectToHost()` → `preparing` → `waitForReady()` → `stateUpdateHandler` 설정 `(continuation A 대기)`
2. 초대 → 같은 endpoint로 `connectToHost()` → `preparing` → `waitForReady()` → `stateUpdateHandler` 덮어씀 `(continuation B 대기)`
3. `connection ready` → `handler 호출` → `continuation B만 resume`
4. continuation **A는 영원히 대기** → `MISUSE (leaked without resume)`

### 해결 방법
- preparing/setup 상태면 그냥 return하여 기존 handler 유지
- `waitForReady` 함수 삭제
- NWConnection 내부 큐잉에 의존하여 ready 대기 불필요

### 정리
- hadler를 continuation 내부에서 설정하지 않고, connection 생성 시 hadler를 설정합니다.
- 이후 새로운 connection을 start()합니다.
- 데이터 수신 시 ready 상태가 아니면 큐에 수신된 데이터 저장, ready 상태 도달 시 `receiveData()` 자동 호출


## 참고 사항
큐잉에 대한 내용은 [WWDC를 참고](https://developer.apple.com/videos/play/wwdc2018/715/)했습니다. 
closes DEV-87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved peer-to-peer connection stability and faster readiness handling to reduce connection delays and reuse existing connections when ready.
* Enhanced error handling, logging, and automatic cleanup for failed or cancelled connections to prevent lingering or stalled peers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->