### PR TITLE
[DEV-112] ClientManager connections 동시 접근(Race Condition) 문제 networkQueue 동기화로 해결

### DIFF
--- a/iOS/Modules/NetworkKit/Sources/Interfaces/ClientManaging.swift
+++ b/iOS/Modules/NetworkKit/Sources/Interfaces/ClientManaging.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Network
 
-public enum ConnectionKind: String, Codable {
+public enum ConnectionKind: String, Codable, Sendable {
     case game
     case video
 }

--- a/iOS/Modules/NetworkKit/Sources/P2P/ClientManager.swift
+++ b/iOS/Modules/NetworkKit/Sources/P2P/ClientManager.swift
@@ -9,8 +9,8 @@ import Foundation
 import Network
 import os
 
-final class ClientManager: ClientManaging {
-    
+final class ClientManager: ClientManaging, @unchecked Sendable {
+
     // MARK: - Properties
     
     private let serviceType = "_cosmicadventure._tcp"
@@ -40,90 +40,132 @@ final class ClientManager: ClientManaging {
     // MARK: - Public Methods
 
     func startBrowsing() {
-        logger.info("탐색 시작: \(self.serviceType)")
+        networkQueue.async { [weak self] in
+            guard let self = self else { return }
+            logger.info("탐색 시작: \(self.serviceType)")
 
-        let parameters = NWParameters()
-        parameters.includePeerToPeer = true
+            let parameters = NWParameters()
+            parameters.includePeerToPeer = true
 
-        browser = NWBrowser(for: .bonjourWithTXTRecord(type: serviceType, domain: nil), using: parameters)
-        
-        browser?.browseResultsChangedHandler = { [weak self] results, changes in
-            self?.handleBrowseResultsChanged(results: results, changes: changes)
+            browser = NWBrowser(for: .bonjourWithTXTRecord(type: serviceType, domain: nil),
+                                using: parameters)
+
+            browser?.browseResultsChangedHandler = { [weak self] results, changes in
+                self?.handleBrowseResultsChanged(results: results, changes: changes)
+            }
+
+            browser?.stateUpdateHandler = { [weak self] state in
+                self?.handleBrowserStateUpdate(state)
+            }
+
+            browser?.start(queue: networkQueue)
         }
-
-        browser?.stateUpdateHandler = { [weak self] state in
-            self?.handleBrowserStateUpdate(state)
-        }
-
-        browser?.start(queue: networkQueue)
     }
 
     func stopBrowsing() {
-        logger.info("탐색 종료")
+        networkQueue.async { [weak self] in
+            guard let self = self else { return }
+            logger.info("탐색 종료")
 
-        connections.values.flatMap { $0.values }.forEach { $0.cancel() }
-        connections.removeAll()
+            connections.values.flatMap { $0.values }.forEach { $0.cancel() }
+            connections.removeAll()
 
-        browser?.cancel()
-        browser = nil
+            browser?.cancel()
+            browser = nil
+        }
     }
 
     func connectToHost(endpoint: NWEndpoint, kind: ConnectionKind) async throws -> NWConnection {
-        if let existingConnection = connections[endpoint]?[kind] {
-            switch existingConnection.state {
-            case .ready:
-                return existingConnection
-            case .preparing, .setup:
-                return existingConnection  // 이미 연결 시도 중이면 그냥 반환 (기존 receiveData가 동작 중)
-            default:
-                existingConnection.cancel()
-                connections[endpoint]?[kind] = nil
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<NWConnection, Error>) in
+
+            networkQueue.async { [weak self] in
+                guard let self = self else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+
+                var hasResumed = false
+
+                if let existingConnection = self.connections[endpoint]?[kind] {
+                    switch existingConnection.state {
+                    case .ready:
+                        continuation.resume(returning: existingConnection)
+                        return
+                    case .preparing, .setup:
+                        continuation.resume(returning: existingConnection)
+                        return
+                    default:
+                        existingConnection.cancel()
+                        self.connections[endpoint]?[kind] = nil
+                    }
+                }
+
+                let parameters = NWParameters.tcp
+                parameters.includePeerToPeer = true
+                let connection = NWConnection(to: endpoint, using: parameters)
+
+                if self.connections[endpoint] == nil {
+                    self.connections[endpoint] = [:]
+                }
+                self.connections[endpoint]?[kind] = connection
+
+                connection.stateUpdateHandler = { [weak self] state in
+                    guard let self = self else {
+                        if !hasResumed {
+                            hasResumed = true
+                            continuation.resume(throwing: CancellationError())
+                        }
+                        return
+                    }
+
+                    switch state {
+                    case .ready:
+                        self.receiveData(from: connection)
+                        if !hasResumed {
+                            hasResumed = true
+                            continuation.resume(returning: connection)
+                        }
+                    case .failed(let error):
+                        self.logger.error("연결 실패: \(error.localizedDescription)")
+                        self.removeConnection(connection)
+                        if !hasResumed {
+                            hasResumed = true
+                            continuation.resume(throwing: error)
+                        }
+                    case .cancelled:
+                        self.removeConnection(connection)
+                        if !hasResumed {
+                            hasResumed = true
+                            continuation.resume(throwing: CancellationError())
+                        }
+                    default:
+                        self.logger.info("연결 상태: \(String(describing: state))")
+                    }
+                }
+
+                connection.start(queue: self.networkQueue) 
             }
         }
-
-        let parameters = NWParameters.tcp
-        parameters.includePeerToPeer = true
-
-        let connection = NWConnection(to: endpoint, using: parameters)
-        if connections[endpoint] == nil {
-            connections[endpoint] = [:]
-        }
-        connections[endpoint]?[kind] = connection
-
-        connection.stateUpdateHandler = { [weak self] state in
-            guard let self else { return }
-            switch state {
-            case .ready:
-                self.receiveData(from: connection)
-            case .failed(let error):
-                self.logger.error("연결 실패: \(error.localizedDescription)")
-                self.removeConnection(connection)
-            case .cancelled:
-                self.removeConnection(connection)
-            default:
-                self.logger.info("연결 상태: \(String(describing: state))")
-            }
-        }
-
-        connection.start(queue: self.networkQueue)
-        return connection
     }
 
     func sendData(_ data: Data, to endpoint: NWEndpoint, kind: ConnectionKind) {
-        guard let connection = connections[endpoint]?[kind] else {
-            logger.error("connection이 존재하지 않습니다.")
-            return
-        }
-
-        logger.info("데이터 전송: \(data.count) bytes")
-
-        connection.send(content: data, isComplete: false, completion: .contentProcessed { [weak self] error in
-            if let error = error {
-                self?.logger.error("데이터 전송 실패: \(error.localizedDescription)")
-            } else {
-                self?.logger.info("데이터 전송 성공")
+        networkQueue.async { [weak self] in
+            guard let self,
+                  let connection = self.connections[endpoint]?[kind] else {
+                self?.logger.error("connection이 존재하지 않습니다.")
+                return
             }
-        })
+
+            logger.info("데이터 전송: \(data.count) bytes")
+            
+            connection.send(content: data, isComplete: false, completion: .contentProcessed { [weak self] error in
+                if let error = error {
+                    self?.logger.error("데이터 전송 실패: \(error.localizedDescription)")
+                } else {
+                    self?.logger.info("데이터 전송 성공")
+                }
+            })
+        }
     }
 
     // MARK: - Private Methods
@@ -213,19 +255,22 @@ final class ClientManager: ClientManaging {
     }
 
     private func removeConnection(_ connection: NWConnection) {
-        let endpoints = Array(connections.keys)
-        for endpoint in endpoints {
-            guard let dict = connections[endpoint] else { continue }
-            let kinds = Array(dict.keys)
-            for kind in kinds {
-                if connections[endpoint]?[kind] === connection {
-                    connections[endpoint]?[kind] = nil
+        networkQueue.async { [weak self] in
+            guard let self else { return }
+            let endpoints = Array(connections.keys)
+            for endpoint in endpoints {
+                guard let dict = connections[endpoint] else { continue }
+                let kinds = Array(dict.keys)
+                for kind in kinds {
+                    if connections[endpoint]?[kind] === connection {
+                        connections[endpoint]?[kind] = nil
+                    }
+                }
+                if connections[endpoint]?.isEmpty == true {
+                    connections[endpoint] = nil
                 }
             }
-            if connections[endpoint]?.isEmpty == true {
-                connections[endpoint] = nil
-            }
+            connection.cancel()
         }
-        connection.cancel()
     }
 }


### PR DESCRIPTION
## 요약
- ClientManager connections 동시 접근(Race Condition) 문제 networkQueue를 통한 동기화로 해결
<br/>

### 작업 목록
- [X] ClientManager connections 동시 접근(Race Condition) 문제 networkQueue를 통한 동기화로 해결
<br/>

## 작업 내용
<img width="700" height="359" alt="a17b4b63-c948-4094-95af-733c7e5ded9c" src="https://github.com/user-attachments/assets/77566423-0368-4f44-a587-6a18db7b20d2" /><br/>

[현상] 여러 기기가 동시에 연결할 때 메모리 주소 충돌(EXC_BAD_ACCESS) 발생.
- ClientManager의connectToHost 함수가 async로 선언되어 있어 여러 기기가 동시에 연결을 시도할 때 서로 다른 스레드에서 self.connections라는 가변 프로퍼티를 동시에 수정하려다 충돌이 발생함.
<br/>

[원인] connections 딕셔너리에 대한 멀티스레드 접근
- 스레드 안전성 부재: connections는 일반 Dictionary이므로 여러 스레드에서 동시에 읽고 쓰기를 시도하면 앱이 즉시 크래시됨.
- async 함수: connectToHost가 async이므로, 시뮬레이터와 기기들이 거의 동시에 브라우징 결과로 서로를 찾아 연결을 시도하면, self.connections[endpoint] = connection 줄에서 충돌이 일어남
<br/>

[해결] networkQueue를 사용하여 딕셔너리 읽기/쓰기 작업을 직렬화(Serialization)함.
- connections에 접근하는 모든 로직을 networkQueue.async 로 감싸서 단 하나의 스레드에서만 딕셔너리를 관리하도록 수정.
    - 데이터 삭제 시에도 안전하게 networkQueue.async 로 감싸서 관리.
<br/>

## 참고사항
- 알림리스트 구현 테스트 진행 중 여러 기기 연결에서 크래시가 나서 미리 진행한 이슈입니다.
<br/>

closes DEV-112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved P2P connection reliability with clearer handling of failures, cancellations, and readiness.
  * Safer, serialized network operations to reduce race conditions during browsing, connecting, sending, and removal.

* **Refactor**
  * Reworked connection lifecycle to an async, queue-serialized flow for more robust setup and error propagation.
  * Connection-related types now declare concurrency conformance for safer async use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->