### PR TITLE
[DEV-115] 낙하 속도 증가에 맞춰 플랫폼 충돌 활성화 보정

### DIFF
--- a/iOS/App/Sources/Presentation/Game/Scene/Controller/PlatformController.swift
+++ b/iOS/App/Sources/Presentation/Game/Scene/Controller/PlatformController.swift
@@ -184,7 +184,7 @@ final class PlatformController {
 
     /// 각 플레이어의 위치(bottomY)와 낙하 속도(dy)를 이용해 플랫폼 충돌 카테고리를 갱신
     /// - NOTE: 빠른 낙하 시 한 프레임 사이에 bottomY가 크게 변할 수 있어 dy*dt 기반 버퍼를 둔다.
-    ///         buffer = min(120, 10 + |dy| * dt)  (dy < 0일 때만 유의미하게 커짐)
+    ///         buffer = min(200, 20 + |dy| * dt * 1.5)  (dy < 0일 때만 유의미하게 커짐)
     func updateCollisions(
         localBottomY: CGFloat?,
         localDY: CGFloat?,
@@ -203,11 +203,11 @@ final class PlatformController {
     }
     
     private func fallBuffer(dy: CGFloat?, dt: TimeInterval) -> CGFloat {
-        let base: CGFloat = 10
+        let base: CGFloat = 20
         guard let dy else { return base }
         // dy < 0(낙하)일 때만 버퍼를 크게(빠른 낙하 랜딩 누락 방지)
-        let extra = dy < 0 ? (-dy) * CGFloat(dt) : 0
-        return min(120, base + extra)
+        let extra = dy < 0 ? (-dy) * CGFloat(dt) * 1.5 : 0
+        return min(200, base + extra)
     }
     
     private func applyCollisionCategories(
@@ -227,7 +227,7 @@ final class PlatformController {
             if let localBottomY {
                 let buffer = fallBuffer(dy: localDY, dt: deltaTime)
                 let isFalling = (localDY ?? 0) <= 0
-                let aboveOrAligned = localBottomY >= topY - 3
+                let aboveOrAligned = localBottomY >= topY - 10
                 if isFalling, aboveOrAligned, topY <= localBottomY + buffer {
                     category.insert(.groundMe)
                 }
@@ -236,7 +236,7 @@ final class PlatformController {
             if let otherBottomY {
                 let buffer = fallBuffer(dy: otherDY, dt: deltaTime)
                 let isFalling = (otherDY ?? 0) <= 0
-                let aboveOrAligned = otherBottomY >= topY - 2
+                let aboveOrAligned = otherBottomY >= topY - 8
                 if isFalling, aboveOrAligned, topY <= otherBottomY + buffer {
                     category.insert(.groundOther)
                 }
@@ -322,5 +322,4 @@ extension PlatformController {
         return names.map { atlas.textureNamed($0) }
     }
 }
-
 


### PR DESCRIPTION
## 요약

빠른 낙하(큰 음수 dy) 상황에서 플랫폼 랜딩이 간헐적으로 누락되던 이슈를 완화하기 위해,
충돌 활성화 임계치와 버퍼 산정 로직을 상향/조정했습니다.

### 작업 목록

* [x] 낙하 버퍼(fallBuffer) 기준값/배수/최대치 상향
* [x] 플랫폼 충돌 활성화 조건(aboveOrAligned) 허용 범위 확장
* [x] 체감 충돌 타이밍 유지 관점에서 파라미터 튜닝

## 작업 내용

### AS-IS

* 낙하 속도가 빨라지면, 프레임 간 이동량이 커지면서 플랫폼 충돌이 활성화되기 전에 지나쳐 랜딩이 누락되는 경우가 있었음
* 플랫폼 상단 근처에 도달해도 충돌 활성화가 한 템포 늦게 걸리는 체감이 있었음

### TO-BE

* 빠른 낙하 시에도 충분한 버퍼를 확보해 플랫폼 충돌 누락이 줄어듦
* 플랫폼 상단 정렬 조건의 허용 범위를 넓혀 충돌 활성화 지연을 완화함
* 전체적으로 충돌 타이밍이 더 안정적으로 느껴지도록 조정함


## 참고 사항

이번 수정으로 “관통하듯 지나치는” 문제는 우선 완화되었지만, 구조적으로는 근본 원인이 남아있습니다.
근본 해결을 위한 이슈를 새로 생성해서, 충돌 판정 방식/활성화 조건 설계를 재검토하고 확실히 해결하는 방향으로 진행하겠습니다.

## 참고 사항

closes DEV-115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform collision detection during fast downward movement by increasing the fall buffer and loosening alignment thresholds.
  * Reduces missed ground detections and makes platform categorization more consistent for both local and remote players.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->