### PR TITLE
[DEV-116] 알림 권한 거부 시 설정으로 이동할 수 있는 Alert 모달 띄우도록 수정

### DIFF
--- a/iOS/App/Sources/Application/AppEntryManager.swift
+++ b/iOS/App/Sources/Application/AppEntryManager.swift
@@ -10,6 +10,7 @@ import Observation
 enum PermissionAlertKind {
     case localNetworkDenied
     case cameraDenied
+    case notificationDenied
 }
 
 @MainActor

--- a/iOS/App/Sources/Presentation/PermissionSetup/PermissionSetupViewModel.swift
+++ b/iOS/App/Sources/Presentation/PermissionSetup/PermissionSetupViewModel.swift
@@ -51,12 +51,12 @@ final class PermissionSetupViewModel {
         let localNetworkGranted = await service.requestLocalNetworkPermissionIfNeeded()
         localNetworkState = localNetworkGranted ? .allowed : .denied
         
-        // 3) 알림 (request but don't block)
+        // 3) 알림
         let notificationGranted = await service.requestNotificationPermission()
         notificationState = notificationGranted ? .allowed : .denied
         
-        // 4) 둘 다 허용되면 설정 완료 표시
-        if cameraGranted && localNetworkGranted {
+        // 4) 셋 다 허용되면 설정 완료 표시
+        if cameraGranted && localNetworkGranted && notificationGranted {
             UserDefaultsList.Permission.hasCompletedPermissionSetup = true
         }
         
@@ -65,6 +65,8 @@ final class PermissionSetupViewModel {
             appEntryManager.presentAlert(.cameraDenied)
         } else if !localNetworkGranted {
             appEntryManager.presentAlert(.localNetworkDenied)
+        } else if !notificationGranted {
+            appEntryManager.presentAlert(.notificationDenied)
         }
         
         // 6) 항상 프로필 설정으로 이동 허용

--- a/iOS/App/Sources/Presentation/Root/RootView.swift
+++ b/iOS/App/Sources/Presentation/Root/RootView.swift
@@ -44,6 +44,8 @@ struct RootView: View {
                     Text(L10N.Alert.localNetworkSubTitle)
                 case .cameraDenied:
                     Text(L10N.Alert.cameraSubTitle)
+                case .notificationDenied:
+                    Text(L10N.Alert.localNetworkSubTitle)
                 }
             }
         }


### PR DESCRIPTION
## 요약
- 알림 권한 거부 시 Alert창을 띄우도록 수정했습니다.

### 작업 목록
- [x] PermissionAlertKind에 알림권한 거부 케이스 추가
- [x] 거부 시 Alert뷰 뜨도록 수정


closes DEV-116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notification permission requests to the app setup process, requiring notification access alongside camera and local network permissions.
  * Users receive alerts when notification permissions are denied during initial setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->