### PR TITLE
[DEV-117] 설정뷰 변경사항이 업데이트되지 않는 문제 개선

### DIFF
--- a/iOS/App/Sources/Application/AppContainer.swift
+++ b/iOS/App/Sources/Application/AppContainer.swift
@@ -14,8 +14,8 @@ import StorageKit
 protocol ViewModelFactory {
     func makePermissionSetupViewModel() -> PermissionSetupViewModel
     func makeProfileSetupViewModel() -> ProfileSetupViewModel
-    func makeLobbyViewModel(playerId: UUID, nickname: String, characterType: String) -> LobbyViewModel
-    func makeGameReadyViewModel(me: PlayerInfo, peer: PlayerInfo?, isNetwork: Bool) -> GameReadyViewModel
+    func makeLobbyViewModel(player: Player) -> LobbyViewModel
+    func makeGameReadyViewModel(localPlayer: PlayerInfo, remotePlayer: PlayerInfo?, isNetwork: Bool) -> GameReadyViewModel
     func makeChannelListViewModel() -> ChannelListViewModel
     func makeSettingsViewModel(player: Player) -> SettingsViewModel
     func makeWebSocketSessionManager(serverURL: String) -> WebSocketSessionManager
@@ -95,23 +95,21 @@ final class AppContainer: ViewModelFactory {
         ProfileSetupViewModel()
     }
     
-    func makeLobbyViewModel(playerId: UUID, nickname: String, characterType: String) -> LobbyViewModel {
+    func makeLobbyViewModel(player: Player) -> LobbyViewModel {
         LobbyViewModel(
             explorationCoordinator: explorationCoordinator,
             connectivityMonitor: connectivityMonitor,
             networkSessionManager: networkSessionManager,
             webSocketSessionManager: webSocketSessionManager,
             appEntryManager: appEntryManager,
-            playerId: playerId,
-            nickname: nickname,
-            characterRawValue: characterType
+            player: player
         )
     }
 
-    func makeGameReadyViewModel(me: PlayerInfo, peer: PlayerInfo?, isNetwork: Bool) -> GameReadyViewModel {
+    func makeGameReadyViewModel(localPlayer: PlayerInfo, remotePlayer: PlayerInfo?, isNetwork: Bool) -> GameReadyViewModel {
         GameReadyViewModel(
-            me: me,
-            peer: peer,
+            localPlayer: localPlayer,
+            remotePlayer: remotePlayer,
             isNetwork: isNetwork,
             connectivityMonitor: connectivityMonitor,
             networkSessionManager: networkSessionManager,

--- a/iOS/App/Sources/Application/AppFlow/AppRoute.swift
+++ b/iOS/App/Sources/Application/AppFlow/AppRoute.swift
@@ -16,10 +16,10 @@ enum AppRoute: Hashable {
     case dashboard
 
     // Game
-    case gameReady(me: PlayerInfo, peer: PlayerInfo?, isNetwork: Bool)
+    case gameReady(localPlayer: PlayerInfo, remotePlayer: PlayerInfo?, isNetwork: Bool)
     case game(PlayerInfo?, isNetwork: Bool = false) // TODO: 나중에 이름 변경
-    case operationGuide(me: PlayerInfo, peer: PlayerInfo?, isNetwork: Bool)
-    case victoryGuide(me: PlayerInfo, peer: PlayerInfo?, isNetwork: Bool)
+    case operationGuide(localPlayer: PlayerInfo, remotePlayer: PlayerInfo?, isNetwork: Bool)
+    case victoryGuide(localPlayer: PlayerInfo, remotePlayer: PlayerInfo?, isNetwork: Bool)
     case result
     
     // Test

--- a/iOS/App/Sources/Presentation/GameReady/GameReadyView.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GameReadyView.swift
@@ -23,14 +23,14 @@ struct GameReadyView: View {
                 Spacer()
 
                 HStack(spacing: 10) {
-                    characterView(player: viewModel.me)
+                    characterView(player: viewModel.localPlayer)
                         .offset(y: isAnimating ? -15 : 0) // 위아래 둥둥 효과
                         .animation(
                             .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
                             value: isAnimating
                         )
 
-                    if let peer = viewModel.peer {
+                    if let peer = viewModel.remotePlayer {
                         characterView(player: peer)
                             .offset(y: isAnimating ? 0 : -15) // 엇박자로 움직임
                             .animation(
@@ -75,7 +75,7 @@ struct GameReadyView: View {
              DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                  Task { @MainActor in
                      guard await appEntryManager.canEnterGame() else { return }
-                     router.push(.game(viewModel.peer, isNetwork: viewModel.isNetwork))
+                     router.push(.game(viewModel.remotePlayer, isNetwork: viewModel.isNetwork))
                  }
              }
          }
@@ -128,8 +128,8 @@ struct GameReadyView_Previews: PreviewProvider {
     static var previews: some View {
         let container = AppContainer()
         GameReadyView(
-            viewModel: container.makeGameReadyViewModel(me: PlayerInfo(role: .me, displayName: "나", avatar: .character1),
-                                                        peer: PlayerInfo(role: .peer, displayName: "상대", avatar: .character2),
+            viewModel: container.makeGameReadyViewModel(localPlayer: PlayerInfo(role: .local, displayName: "나", avatar: .character1),
+                                                        remotePlayer: PlayerInfo(role: .remote, displayName: "상대", avatar: .character2),
                                                         isNetwork: false)
         )
     }

--- a/iOS/App/Sources/Presentation/GameReady/GameReadyViewModel.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GameReadyViewModel.swift
@@ -11,8 +11,8 @@ import NetworkKit
 @MainActor
 @Observable
 final class GameReadyViewModel {
-    let me: PlayerInfo
-    let peer: PlayerInfo?
+    let localPlayer: PlayerInfo
+    let remotePlayer: PlayerInfo?
     let isNetwork: Bool
 
     @ObservationIgnored
@@ -38,16 +38,16 @@ final class GameReadyViewModel {
     let appEntryManager: AppEntryManager
 
     init(
-        me: PlayerInfo,
-        peer: PlayerInfo?,
+        localPlayer: PlayerInfo,
+        remotePlayer: PlayerInfo?,
         isNetwork: Bool,
         connectivityMonitor: ConnectivityMonitoring,
         networkSessionManager: NetworkSessionManaging,
         webSocketSessionManager: WebSocketSessionManaging?,
         appEntryManager: AppEntryManager
     ) {
-        self.me = me
-        self.peer = peer
+        self.localPlayer = localPlayer
+        self.remotePlayer = remotePlayer
         self.isNetwork = isNetwork
         self.connectivityMonitor = connectivityMonitor
         self.networkSessionManager = networkSessionManager
@@ -72,7 +72,7 @@ final class GameReadyViewModel {
         // 본인의 Ready를 UI에 즉시 반영
         updateProgressUI()
 
-        if peer == nil {
+        if remotePlayer == nil {
             Task {
                 // TODO: game map load 되는 시점으로 변경
                 try? await Task.sleep(for: .seconds(3))
@@ -125,7 +125,8 @@ final class GameReadyViewModel {
     private func setupP2PCallbacks() {
         networkSessionManager.onReadyStatusReceived = { [weak self] senderId in
             guard let self else { return }
-            guard let peerId = peer?.id, senderId == peerId else { return }
+            guard let remoteId = remotePlayer?.id,
+                    senderId == remoteId else { return }
 
             Task { @MainActor in
                 self.handlePeerReady()
@@ -136,7 +137,8 @@ final class GameReadyViewModel {
     private func setupWebSocketCallbacks() {
         webSocketSessionManager?.onReadyStatusReceived = { [weak self] senderId in
             guard let self else { return }
-            guard let peerId = self.peer?.id, senderId == peerId else { return }
+            guard let remoteId = self.remotePlayer?.id,
+                    senderId == remoteId else { return }
 
             Task { @MainActor in
                 self.handlePeerReady()
@@ -145,14 +147,14 @@ final class GameReadyViewModel {
     }
 
     private func sendReadySignal() {
-        guard let peerId = peer?.id else { return }
+        guard let remoteId = remotePlayer?.id else { return }
 
         switch networkMode {
         case .local:
-            networkSessionManager.sendReadyStatus(to: peerId)
+            networkSessionManager.sendReadyStatus(to: remoteId)
 
         case .remote:
-            webSocketSessionManager?.sendReadyStatus(to: peerId)
+            webSocketSessionManager?.sendReadyStatus(to: remoteId)
         }
     }
 
@@ -165,7 +167,7 @@ final class GameReadyViewModel {
 
     private func updateProgressUI() {
         // 1인 모드
-        if peer == nil {
+        if remotePlayer == nil {
             if isMeReady && isPeerReady {
                 progress = 1.0
                 message = L10N.GameReady.soloReadyMessage

--- a/iOS/App/Sources/Presentation/GameReady/GuideView/OperationGuideView.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GuideView/OperationGuideView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct OperationGuideView: View {
     @Environment(AppRouter.self) private var router: AppRouter
 
-    let me: PlayerInfo
-    let peer: PlayerInfo?
+    let localPlayer: PlayerInfo
+    let remotePlayer: PlayerInfo?
     let isNetwork: Bool
     
     var body: some View {
@@ -53,7 +53,7 @@ struct OperationGuideView: View {
                     title: L10N.Game.Guide.gotoVictoryCondition,
                     verticalPadding: 16
                 ) {
-                    router.push(.victoryGuide(me: me, peer: peer, isNetwork: isNetwork))
+                    router.push(.victoryGuide(localPlayer: localPlayer, remotePlayer: remotePlayer, isNetwork: isNetwork))
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 59)
@@ -64,8 +64,8 @@ struct OperationGuideView: View {
 }
 
 #Preview {
-    OperationGuideView(me: PlayerInfo(role: .me, displayName: "나", avatar: .character1),
-                       peer: PlayerInfo(role: .peer, displayName: "상대", avatar: .character2),
+    OperationGuideView(localPlayer: PlayerInfo(role: .local, displayName: "나", avatar: .character1),
+                       remotePlayer: PlayerInfo(role: .remote, displayName: "상대", avatar: .character2),
                        isNetwork: false)
         .environment(AppRouter())
 }

--- a/iOS/App/Sources/Presentation/GameReady/GuideView/VictoryGuideView.swift
+++ b/iOS/App/Sources/Presentation/GameReady/GuideView/VictoryGuideView.swift
@@ -12,8 +12,8 @@ struct VictoryGuideView: View {
     @Environment(AppEntryManager.self) private var appEntryManager: AppEntryManager
     @State private var isChecked: Bool = UserDefaultsList.Game.isGuideChecked
 
-    let me: PlayerInfo
-    let peer: PlayerInfo?
+    let localPlayer: PlayerInfo
+    let remotePlayer: PlayerInfo?
     let isNetwork: Bool
     
     var body: some View {
@@ -48,7 +48,7 @@ struct VictoryGuideView: View {
                 ) {
                     Task { @MainActor in
                         guard await appEntryManager.canEnterGame() else { return }
-                        router.push(.gameReady(me: me, peer: peer, isNetwork: isNetwork))
+                        router.push(.gameReady(localPlayer: localPlayer, remotePlayer: remotePlayer, isNetwork: isNetwork))
                     }
                 }
                 .padding(.horizontal, 20)
@@ -76,8 +76,8 @@ struct VictoryGuideView: View {
 }
 
 #Preview {
-    VictoryGuideView(me: PlayerInfo(role: .me, displayName: "나", avatar: .character1),
-                     peer: PlayerInfo(role: .peer, displayName: "상대", avatar: .character2),
+    VictoryGuideView(localPlayer: PlayerInfo(role: .local, displayName: "나", avatar: .character1),
+                     remotePlayer: PlayerInfo(role: .remote, displayName: "상대", avatar: .character2),
                      isNetwork: false)
         .environment(AppRouter())
 }

--- a/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
+++ b/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
@@ -47,21 +47,8 @@ struct LobbyView: View {
                 Task { await channelListViewModel.fetchChannels() }
             }
         }
-         .onChange(of: viewModel.matchStatus) { _, newValue in
-             if case .gameReady(let peer) = newValue {
-                 if UserDefaultsList.Game.isGuideChecked {
-                     Task { @MainActor in
-                         guard await appEntryManager.canEnterGame() else { return }
-                         router.push(.gameReady(me: viewModel.localPlayer,
-                                                peer: peer,
-                                                isNetwork: viewModel.networkMode == .remote))
-                     }
-                } else {
-                    router.push(.operationGuide(me: viewModel.localPlayer,
-                                                peer: peer,
-                                                isNetwork: viewModel.networkMode == .remote))
-                }
-            }
+        .onChange(of: viewModel.matchStatus) { _, newValue in
+            handleMatchStatusChange(newValue)
         }
         .overlay {
             if isModalPresented {
@@ -91,6 +78,23 @@ struct LobbyView: View {
         let isInSettings = newPath.contains(.settings)
         if wasInSettings && !isInSettings {
             viewModel.setupExploration()
+        }
+    }
+
+    private func handleMatchStatusChange(_ newValue: GameMatchStatus) {
+        guard case .gameReady(let remotePlayer) = newValue else { return }
+
+        if UserDefaultsList.Game.isGuideChecked {
+            Task { @MainActor in
+                guard await appEntryManager.canEnterGame() else { return }
+                router.push(.gameReady(localPlayer: viewModel.localPlayer,
+                                       remotePlayer: remotePlayer,
+                                       isNetwork: viewModel.networkMode == .remote))
+            }
+        } else {
+            router.push(.operationGuide(localPlayer: viewModel.localPlayer,
+                                        remotePlayer: remotePlayer,
+                                        isNetwork: viewModel.networkMode == .remote))
         }
     }
 }
@@ -167,13 +171,13 @@ private extension LobbyView {
                  if UserDefaultsList.Game.isGuideChecked {
                      Task { @MainActor in
                          guard await appEntryManager.canEnterGame() else { return }
-                         router.push(.gameReady(me: viewModel.localPlayer,
-                                                peer: nil,
+                         router.push(.gameReady(localPlayer: viewModel.localPlayer,
+                                                remotePlayer: nil,
                                                 isNetwork: viewModel.networkMode == .remote))
                      }
                 } else {
-                    router.push(.operationGuide(me: viewModel.localPlayer,
-                                                peer: nil,
+                    router.push(.operationGuide(localPlayer: viewModel.localPlayer,
+                                                remotePlayer: nil,
                                                 isNetwork: viewModel.networkMode == .remote))
                 }
             }

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+P2P.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+P2P.swift
@@ -63,15 +63,15 @@ extension LobbyViewModel {
         }
     }
 
-    func updateLocalPeers(_ peers: [NetworkPeer]) {
-        self.peers = peers.enumerated().map { index, peer in
+    func updateLocalPeers(_ remotePlayers: [NetworkPeer]) {
+        self.remotePlayers = remotePlayers.enumerated().map { index, peer in
             let discoveryLatency = Double(index * 10 + 5)
             let effectiveLatency = peer.latency ?? discoveryLatency
             let proximity = calculateProximity(latency: effectiveLatency)
             
             return PlayerInfo(
                 id: peer.sessionId,
-                role: .peer,
+                role: .remote,
                 displayName: peer.name,
                 avatar: .character1,
                 proximity: proximity

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+WebSocket.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel+WebSocket.swift
@@ -25,7 +25,7 @@ extension LobbyViewModel {
             Task { @MainActor in
                 self?.isConnected = connected
                 if !connected {
-                    self?.peers = []
+                    self?.remotePlayers = []
                     self?.selectedPeerID = nil
                     self?.matchStatus = .idle
                 }
@@ -90,11 +90,11 @@ extension LobbyViewModel {
 extension LobbyViewModel {
 
     func updatePeersFromPlayers(_ players: [WebSocketPlayer]) {
-        peers = players.map { player in
+        remotePlayers = players.map { player in
             let proximity = calculateProximity(latency: player.latency)
             return PlayerInfo(
                 id: player.id,
-                role: .peer,
+                role: .remote,
                 displayName: player.nickname,
                 avatar: randomAvatar(),
                 proximity: proximity
@@ -103,22 +103,22 @@ extension LobbyViewModel {
     }
 
     func addPeer(from player: WebSocketPlayer) {
-        guard peers.contains(where: { $0.id == player.id }) == false else { return }
+        guard remotePlayers.contains(where: { $0.id == player.id }) == false else { return }
 
         let proximity = calculateProximity(latency: player.latency)
 
         let player = PlayerInfo(
             id: player.id,
-            role: .peer,
+            role: .remote,
             displayName: player.nickname,
             avatar: randomAvatar(),
             proximity: proximity
         )
-        peers.append(player)
+        remotePlayers.append(player)
     }
 
     func removePeer(playerId: UUID) {
-        peers.removeAll { $0.id == playerId }
+        remotePlayers.removeAll { $0.id == playerId }
 
         if selectedPeerID == playerId {
             selectedPeerID = nil

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
@@ -35,7 +35,7 @@ final class LobbyViewModel {
             avatar: CharacterAvatar(rawValue: player.character) ?? .character1)
     }
 
-    var peers: [PlayerInfo] = []
+    var remotePlayers: [PlayerInfo] = []
     var selectedPeerID: UUID?
 
     // Network State
@@ -72,7 +72,7 @@ final class LobbyViewModel {
     }
 
     var orderedPeers: [PlayerInfo] {
-        peers.sorted { lhs, rhs in
+        remotePlayers.sorted { lhs, rhs in
             switch (lhs.proximity, rhs.proximity) {
             case let (l?, r?): return l < r
             case (_?, nil): return true
@@ -196,7 +196,7 @@ extension LobbyViewModel {
     func leaveChannel() {
         explorationCoordinator.stopExploration()
         selectedChannelId = nil
-        peers = []
+        remotePlayers = []
     }
 }
 
@@ -209,8 +209,8 @@ extension LobbyViewModel {
     }
 
     func updateProximity(for playerID: UUID, value: Double) {
-        guard let index = peers.firstIndex(where: { $0.id == playerID }) else { return }
-        peers[index].proximity = max(0, min(1, value))
+        guard let index = remotePlayers.firstIndex(where: { $0.id == playerID }) else { return }
+        remotePlayers[index].proximity = max(0, min(1, value))
     }
 
     func calculateProximity(latency: Double?) -> Double {
@@ -246,7 +246,7 @@ extension LobbyViewModel {
 
 extension LobbyViewModel {
     func handleInviteReceived(from senderId: UUID) {
-        guard let peer = peers.first(where: { $0.id == senderId }) else {
+        guard let peer = remotePlayers.first(where: { $0.id == senderId }) else {
             logger.warning("초대한 피어를 찾을 수 없음: \(senderId.uuidString)")
             return
         }
@@ -269,7 +269,7 @@ extension LobbyViewModel {
     }
 
     func handleInviteAccepted(from senderId: UUID) {
-        guard let peer = peers.first(where: { $0.id == senderId }) else { return }
+        guard let peer = remotePlayers.first(where: { $0.id == senderId }) else { return }
 
         if case .sendingRequest = matchStatus {
             matchStatus.setGameReady(with: peer)
@@ -277,7 +277,7 @@ extension LobbyViewModel {
     }
 
     func handleInviteDeclined(from senderId: UUID) {
-        guard let peer = peers.first(where: { $0.id == senderId }) else { return }
+        guard let peer = remotePlayers.first(where: { $0.id == senderId }) else { return }
 
         if case .sendingRequest = matchStatus {
             matchStatus.requestDeclined(by: peer)

--- a/iOS/App/Sources/Presentation/Root/RootView.swift
+++ b/iOS/App/Sources/Presentation/Root/RootView.swift
@@ -70,9 +70,6 @@ struct RootView: View {
         case .lobby:
             if let localPlayer = players.first {
                 LobbyView(viewModel: container.makeLobbyViewModel(player: localPlayer),
-                            container.makeLobbyViewModel(playerId: myPlayer.id,
-                                                         nickname: myPlayer.nickname,
-                                                         characterType: myPlayer.character),
                           channelListViewModel: container.makeChannelListViewModel()
                 )
             }
@@ -80,18 +77,18 @@ struct RootView: View {
             // TODO: DashboardView 연결
             EmptyView()
         case .settings:
-            if let player = players.first {
-                SettingsView(viewModel: container.makeSettingsViewModel(player: player))
+            if let localPlayer = players.first {
+                SettingsView(viewModel: container.makeSettingsViewModel(player: localPlayer))
             }
-        case .gameReady(let me, let peer, let isNetwork):
-            GameReadyView(viewModel: container.makeGameReadyViewModel(me: me,
-                                                                      peer: peer,
+        case .gameReady(let localPlayer, let remotePlayer, let isNetwork):
+            GameReadyView(viewModel: container.makeGameReadyViewModel(localPlayer: localPlayer,
+                                                                      remotePlayer: remotePlayer,
                                                                       isNetwork: isNetwork))
         case .game(let matchPeer, let isNetwork):
             if let myPlayer = players.first {
                 let me = PlayerInfo(
                     id: myPlayer.id,
-                    role: .me,
+                    role: .local,
                     displayName: myPlayer.nickname,
                     avatar: CharacterAvatar.init(rawValue: myPlayer.character)
                     ?? .character1
@@ -107,13 +104,13 @@ struct RootView: View {
                     videoManager: container.makeVideoManager(isNetwork: isNetwork)
                 )
             }
-        case .operationGuide(let me, let peer, let isNetwork):
-            OperationGuideView(me: me,
-                               peer: peer,
+        case .operationGuide(let local, let remote, let isNetwork):
+            OperationGuideView(localPlayer: local,
+                               remotePlayer: remote,
                                isNetwork: isNetwork)
-        case .victoryGuide(let me, let peer, let isNetwork):
-            VictoryGuideView(me: me,
-                             peer: peer,
+        case .victoryGuide(let local, let remote, let isNetwork):
+            VictoryGuideView(localPlayer: local,
+                             remotePlayer: remote,
                              isNetwork: isNetwork)
         case .result:
             // TODO: ResultView 연결

--- a/iOS/App/Sources/Presentation/Settings/SettingsViewModel.swift
+++ b/iOS/App/Sources/Presentation/Settings/SettingsViewModel.swift
@@ -17,7 +17,7 @@ final class SettingsViewModel {
     
     // MARK: - Properties
     
-    private let logger = Logger(subsystem: "com.cosmicadventure.app", category: "LobbyViewModel")
+    private let logger = Logger(subsystem: "com.cosmicadventure.app", category: "SettingsViewModel")
     
     var nickname: String
     var selectedAvatar: CharacterAvatar

--- a/iOS/App/Sources/Presentation/Shared/Models/PlayerInfo.swift
+++ b/iOS/App/Sources/Presentation/Shared/Models/PlayerInfo.swift
@@ -10,8 +10,8 @@ import Foundation
 // MARK: - Player Role
 
 enum PlayerRole: Equatable {
-    case me
-    case peer
+    case local
+    case remote
 }
 
 // MARK: - Player Info
@@ -24,7 +24,7 @@ struct PlayerInfo: Identifiable, Equatable, Hashable {
 
     /// 수신 감도/근접도: 0.0~1.0, 값이 클수록 내 위치에 더 가까움
     /// - nil이면 아직 미측정/알 수 없음
-    /// - peer만 의미 있음 (me는 항상 중앙 고정)
+    /// - remote만 의미 있음 (local는 항상 중앙 고정)
     var proximity: Double?
 
     init(


### PR DESCRIPTION
## 요약
- 설정뷰에서 플레이어 정보 수정사항이 SwiftData에 반영되도록 개선했습니다.
- LobbyView에서는 변경된 데이터를 보여주도록 수정했습니다.
- `me -> localPlayer`, `peer -> remotePlayer`로 명칭을 수정했습니다.

### 작업 목록
- [x] SettingsViewModel에서 `modelContext.save()` 호출
- [x] LobbyViewModel에서 Player 값으로 PlayerInfo 생성

## 작업 내용
### 변경사항 SwiftData에 저장
```swift
/// SettingsViewModel.swift
func saveProfile(modelContext: ModelContext) {
    player.nickname = nickname.isEmpty ? player.nickname : nickname
    player.character = selectedAvatar.rawValue

   // 추가된 부분
    do {
        try modelContext.save()
    } catch {
        logger.error("[SettingsViewModel] 플레이어 정보 저장에 실패했습니다: \(error.localizedDescription)")
    }
}
```
- 기존에는 변경사항을 설정 뷰모델만 알고 있었음
- `modelContext.save()`를 호출하여 SwiftData에 변경 사항 저장

### LobbyViewModel의 PlayerInfo 초기화 방식 수정
**AS-IS**
- 기존에는 `PlayerInfo`가 init 시점에 초기화되어 한 번 정해지면 변경되지 않음

**TO-BE**
- `PlayerInfo`가 아닌 `Player(SwiftData에 저장된 값)`을 init시점에 주입
- `Player`값이 변경되면 `PlayerInfo`가 업데이트 되도록 개선

### 설정 변경 후 `setupExploration` 호출
- 설정뷰에서 `LobbyView`로 돌아온 경우에는 `setupExploration` 메소드를 호출하도록 개선했습니다. (통신 시 닉네임을 사용하고 있기 때문)

### UI 변경
https://github.com/user-attachments/assets/cd882b2b-64be-4a18-be47-dba6096bde07


## 참고 사항

closes DEV-117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified player role naming and cleaned up player-management across the app for clearer behavior.

* **Improvements**
  * Smoother lobby routing and match-entry flow, with clearer solo vs duo readiness handling.
  * Tweaked game-ready animations: remote player now animates with a short delay for improved visual pacing.

* **Chores**
  * Enhanced error logging in settings for better diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->