### PR TITLE
[DEV-118] 첫 설치 이후 권한 설정후 근거리 탐색시 권한 묻는 문제 수정

### DIFF
--- a/iOS/App/Sources/Core/Permission/LocalNetworkPermissionRequester.swift
+++ b/iOS/App/Sources/Core/Permission/LocalNetworkPermissionRequester.swift
@@ -17,8 +17,12 @@ final class LocalNetworkPermissionRequester: LocalNetworkPermissionRequesting {
 
     /// 초기 권한 요청을 위한 임시 세션을 실행하고 결과를 반환합니다.
     func requestPermission(hostName: String) async -> Bool {
-        await AsyncStream { continuation in
+        return await AsyncStream { continuation in
+            var timeoutTask: Task<Void, Never>?
+
             networkSessionManager.onPermissionResult = { [weak self] result in
+                timeoutTask?.cancel()
+
                 switch result {
                 case .success:
                     continuation.yield(true)
@@ -32,9 +36,10 @@ final class LocalNetworkPermissionRequester: LocalNetworkPermissionRequesting {
             networkSessionManager.activate(nickname: hostName)
 
             // 초기 요청 시 응답이 없을 경우를 대비한 타임아웃
-            Task {
+            timeoutTask = Task { [weak self] in
                 try? await Task.sleep(for: .seconds(3))
-                networkSessionManager.deactivate()
+                guard !Task.isCancelled else { return }
+                self?.networkSessionManager.deactivate()
                 continuation.yield(false)
                 continuation.finish()
             }

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
@@ -55,6 +55,10 @@ final class LobbyViewModel {
     @ObservationIgnored
     let appEntryManager: AppEntryManager
 
+    /// setupExploration()에서 생성한 권한 체크 Task. 중복 호출 시 이전 Task를 cancel하기 위해 보관.
+    @ObservationIgnored
+    private var permissionCheckTask: Task<Void, Never>?
+
     // MARK: - Computed Properties
 
     var isNetworkAvailable: Bool {
@@ -154,10 +158,13 @@ extension LobbyViewModel {
     }
 
     func setupExploration() {
+        permissionCheckTask?.cancel()
+
         switch networkMode {
         case .local:
-            Task {
+            permissionCheckTask = Task {
                 let isPermissionGranted = await appEntryManager.isLocalNetworkPermissionGranted()
+                guard !Task.isCancelled else { return }
                 if !isPermissionGranted {
                     appEntryManager.presentAlert(.localNetworkDenied)
                     matchStatus.reset()


### PR DESCRIPTION
## 증상

첫 설치 → 권한 모두 허용 → 로비 → **"근처의 은하 탐색하기"** 탭 →  
로컬 네트워크 권한이 허용되었음에도 **"거부됨" Alert이 표시**됨.  
앱 종료 후 재실행하면 정상 동작.


### 수정 전 UI


https://github.com/user-attachments/assets/c9402954-d4dd-4754-a498-d72546316469

### 수정 후 UI


https://github.com/user-attachments/assets/d51b5d78-6df8-4a8c-a7ee-0dedcc485194



## 원인

두 가지 레이스 컨디션이 결합되어 발생.

### 1. `setupExploration()` 중복 호출로 인한 콜백 덮어쓰기

```
LobbyView.onAppear → setup() → setupExploration()
                      setupConnectivityMonitor() → handleConnectivityChange() → setupExploration()  (두 번째 호출)
```

SwiftUI 라이프사이클 특성상 `setup()`이 두 번 호출될 수 있고, 각 호출이 독립적인 `Task`를 생성하여 권한 체크를 **동시에** 수행하게 됨.

`LocalNetworkPermissionRequester.requestPermission()`은 내부에서 `NetworkSessionManager.onPermissionResult` 클로저를 설정하는데, 이 프로퍼티는 **단일 클로저**이므로 두 번째 호출이 첫 번째 콜백을 **덮어씀**.  
→ 첫 번째 Task의 콜백은 영원히 호출되지 않음.

### 2. 취소 불가능한 타임아웃 Task

`requestPermission()` 내부의 3초 타임아웃 Task가 **fire-and-forget**으로 생성되어, 콜백이 정상 수신되더라도 타임아웃이 여전히 실행됨.

콜백을 받지 못한 첫 번째 Task의 타임아웃이 3초 후 `false`를 반환 → **"권한 거부" Alert 표시**.

## 수정 내용

### `LocalNetworkPermissionRequester` — 타임아웃 레이스 컨디션 해소

| Before | After |
|--------|-------|
| 타임아웃 Task가 fire-and-forget | `var timeoutTask`에 저장 |
| 콜백 수신 후에도 타임아웃 실행 | 콜백에서 `timeoutTask?.cancel()` 호출 |
| cancel 후에도 실행 가능 | `guard !Task.isCancelled` 추가 |
| `networkSessionManager` 강한 캡처 | `[weak self]` 캡처로 메모리 누수 방지 |

### `LobbyViewModel` — 중복 권한 체크 방지

| Before | After |
|--------|-------|
| `setupExploration()`마다 새 Task 생성 (추적 안 됨) | `permissionCheckTask` 프로퍼티에 저장 |
| 이전 Task가 계속 실행됨 | 진입 시 `permissionCheckTask?.cancel()` |
| 취소된 Task도 결과를 처리함 | `guard !Task.isCancelled` 추가 |

## 변경 파일

- `iOS/App/Sources/Core/Permission/LocalNetworkPermissionRequester.swift`
- `iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local network permission request handling with automatic timeout support to prevent indefinite hangs during permission prompts.
  * Enhanced permission check serialization to prevent overlapping or duplicate requests when rapidly switching between navigation modes.
  * Streamlined resource cleanup and cancellation handling to ensure proper management when permission requests are interrupted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->