### PR TITLE
[DEV-119] 앱 초기 진입 시 화면 플리커 3종 제거

### DIFF
--- a/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
+++ b/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
@@ -24,12 +24,16 @@ struct LobbyView: View {
         @Bindable var viewModel = viewModel
 
         BackgroundContainerView {
-            VStack(spacing: 0) {
-                topBar
-                    .padding(.top, 60)
-                    .padding(.horizontal, 20)
-                
-                if viewModel.networkMode == .remote && viewModel.selectedChannelId == nil {
+             VStack(spacing: 0) {
+                 topBar
+                     .padding(.top, 60)
+                     .padding(.horizontal, 20)
+
+                 // ConnectivityMonitor의 첫 번째 콜백이 오기 전까지 networkMode가 확정되지 않으므로,
+                 // resolved 전에는 중립적 placeholder를 표시하여 local↔remote 전환 깜빡임을 방지.
+                 if !viewModel.isConnectivityResolved {
+                    loadingContent
+                } else if viewModel.networkMode == .remote && viewModel.selectedChannelId == nil {
                     channelListContent
                 } else {
                     lobbyContent
@@ -38,6 +42,12 @@ struct LobbyView: View {
         }
         .onAppear {
             viewModel.setup()
+
+            // onChange는 값이 '변경'될 때만 트리거되므로, 이미 remote 모드로 진입한 경우
+            // 채널 목록을 불러오지 못함. onAppear에서도 fetch를 호출하여 이를 보완.
+            if viewModel.networkMode == .remote && viewModel.selectedChannelId == nil {
+                Task { await channelListViewModel.fetchChannels() }
+            }
         }
         .onChange(of: router.path) { oldPath, newPath in
             handleRouteChange(from: oldPath, to: newPath)
@@ -125,28 +135,37 @@ private extension LobbyView {
     }
 
     // TODO: 채널 목록 로드 실패 시 분기 처리 (네트워크 끊김 등)
-    @ViewBuilder
-    var channelListContent: some View {
-        AppAsset.Image.titleLogo.swiftUIImage
-            .resizable()
-            .scaledToFit()
-            .frame(height: 100)
-            .padding(.top, 20)
-        
-        if channelListViewModel.channels.isEmpty {
-            ChannelEmptyView()
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 12) {
-                    ForEach(channelListViewModel.channels) { channel in
-                        // TODO: 채널 입장 후 연결 실패 시 분기 처리
-                        ChannelRowView(channel: channel) {
-                            viewModel.selectChannel(channel.id)
+     @ViewBuilder
+     var channelListContent: some View {
+         AppAsset.Image.titleLogo.swiftUIImage
+             .resizable()
+             .scaledToFit()
+             .frame(height: 100)
+             .padding(.top, 20)
+
+         // channels 배열이 비어있는 것이 '로딩 중'인지 '정말 없는 것'인지 구분하기 위해
+         // LoadState 기반으로 분기. idle/loading 시 placeholder, loaded 시에만 실제 목록 표시.
+         switch channelListViewModel.loadState {
+         case .idle, .loading:
+             loadingContent
+        case .failed:
+            channelLoadFailedContent
+        case .loaded:
+            if channelListViewModel.channels.isEmpty {
+                ChannelEmptyView()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(channelListViewModel.channels) { channel in
+                            // TODO: 채널 입장 후 연결 실패 시 분기 처리
+                            ChannelRowView(channel: channel) {
+                                viewModel.selectChannel(channel.id)
+                            }
                         }
                     }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 20)
                 }
-                .padding(.horizontal, 20)
-                .padding(.top, 20)
             }
         }
         
@@ -156,6 +175,25 @@ private extension LobbyView {
             secondaryTitle: L10N.Lobby.localGalaxyButtonTitle,
             secondaryAction: { viewModel.switchNetworkMode(to: .local) }
         )
+    }
+
+    /// 비동기 상태가 확정되기 전에 표시되는 공통 로딩 placeholder.
+    /// ConnectivityMonitor 콜백 대기, 채널 목록 네트워크 요청 등에서 사용한다.
+    var loadingContent: some View {
+        LoadingPlaceholderView()
+    }
+
+     /// 채널 목록 로드 실패 시 표시되는 뷰. 재시도 버튼을 포함한다.
+     @ViewBuilder
+     var channelLoadFailedContent: some View {
+        Spacer()
+        ChannelEmptyView()
+        Spacer()
+        PrimaryGradientButton(title: "다시 시도", isSubtle: true) {
+            Task { await channelListViewModel.fetchChannels() }
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 12)
     }
     
     @ViewBuilder

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/ChannelListViewModel.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/ChannelListViewModel.swift
@@ -11,9 +11,20 @@ import Observation
 @MainActor
 @Observable
 final class ChannelListViewModel {
-    
+
+    /// 채널 목록의 로딩 상태를 구분하기 위한 enum.
+    /// channels 배열이 비어있는 것이 '로딩 중'인지 '정말 없는 것'인지 구분할 수 없어
+    /// 로딩 중에도 ChannelEmptyView가 표시되는 플리커를 방지한다.
+    enum LoadState {
+        case idle
+        case loading
+        case loaded
+        case failed
+    }
+     
     private(set) var channels: [Channel] = []
-    
+    private(set) var loadState: LoadState = .idle
+     
     private let channelService: ChannelServiceProtocol
     
     init(channelService: ChannelServiceProtocol) {
@@ -21,10 +32,14 @@ final class ChannelListViewModel {
     }
     
     func fetchChannels() async {
+        // 중복 네트워크 요청 방지. 이미 로딩 중이면 무시.
+        guard loadState != .loading else { return }
+        loadState = .loading
         do {
             channels = try await channelService.fetchChannels()
+            loadState = .loaded
         } catch {
-            channels = []
+            loadState = .failed
         }
     }
 }

--- a/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
+++ b/iOS/App/Sources/Presentation/Lobby/ViewModels/LobbyViewModel.swift
@@ -42,6 +42,10 @@ final class LobbyViewModel {
     var isConnected = false
     private(set) var networkMode: NetworkMode = .local
     var selectedChannelId: String?
+    /// ConnectivityMonitor의 첫 번째 콜백이 오기 전까지 false.
+    /// LobbyView에서 이 값이 true가 될 때까지 중립적 placeholder를 표시하여
+    /// local↔remote 전환 시 발생하는 깜빡임을 방지한다.
+    private(set) var isConnectivityResolved = false
 
     // Match State
     var matchStatus: GameMatchStatus = .idle
@@ -68,6 +72,11 @@ final class LobbyViewModel {
     /// setupExploration()에서 생성한 권한 체크 Task. 중복 호출 시 이전 Task를 cancel하기 위해 보관.
     @ObservationIgnored
     private var permissionCheckTask: Task<Void, Never>?
+    
+    @ObservationIgnored
+    /// SwiftUI 라이프사이클 특성상 onAppear가 여러 번 호출될 수 있으므로,
+    /// setup()의 중복 실행을 방지하기 위한 플래그.
+    private var didSetup = false
 
     // MARK: - Computed Properties
 
@@ -106,10 +115,15 @@ final class LobbyViewModel {
     }
 
     func setup() {
+        // SwiftUI의 onAppear가 여러 번 호출되어도 setup은 한 번만 실행되도록 보장.
+        guard !didSetup else { return }
+        didSetup = true
         setupConnectivityMonitor()
         setupP2PCallbacks()
         setupWebSocketCallbacks()
-        setupExploration()
+        // setupExploration()은 여기서 직접 호출하지 않음.
+        // ConnectivityMonitor의 첫 콜백(handleConnectivityChange)에서 호출되므로
+        // networkMode가 확정된 후에만 탐색이 시작된다.
         setupNotificationHandlers()
         resetToIdle()
     }
@@ -134,10 +148,13 @@ extension LobbyViewModel {
             }
         }
         connectivityMonitor.start()
-        networkMode = connectivityMonitor.isConnected ? .remote : .local
     }
 
     private func handleConnectivityChange(isConnected: Bool) {
+        // ConnectivityMonitor 콜백에서 실제 네트워크 상태를 받아 확정.
+        // isConnectivityResolved를 true로 설정하여 LobbyView가 placeholder 대신 실제 UI를 렌더링하도록 함.
+        self.isConnected = isConnected
+        isConnectivityResolved = true
         if isConnected {
             networkMode = .remote
         } else {

--- a/iOS/App/Sources/Presentation/Root/RootView.swift
+++ b/iOS/App/Sources/Presentation/Root/RootView.swift
@@ -16,7 +16,11 @@ struct RootView: View {
 
     init(container: AppContainer? = nil, router: AppRouter? = nil) {
         self.container = container ?? AppContainer()
-        _router = State(initialValue: router ?? AppRouter())
+        // AppRouter 기본값이 .permissionSetup이므로, 비동기 checkUserStatus()가 올바른 root를 설정하기 전에
+        // SwiftUI가 첫 프레임을 렌더링하면 PermissionSetupView가 한 프레임 깜빡임.
+        // 이를 방지하기 위해 UserDefaults를 동기적으로 읽어 init 시점에 올바른 초기 라우트를 결정.
+        let initialRouter = router ?? AppRouter(initial: Self.initialRootRoute())
+        _router = State(initialValue: initialRouter)
     }
 
     var body: some View {
@@ -72,14 +76,22 @@ struct RootView: View {
                 LobbyView(viewModel: container.makeLobbyViewModel(player: localPlayer),
                           channelListViewModel: container.makeChannelListViewModel()
                 )
-            }
+            } else {
+                 // SwiftData @Query가 아직 로딩 중이면 players.first가 nil이므로,
+                 // 빈 화면 대신 로고 placeholder를 표시하여 깜빡임 방지.
+                 playerLoadingView
+             }
         case .dashboard:
             // TODO: DashboardView 연결
             EmptyView()
         case .settings:
             if let localPlayer = players.first {
                 SettingsView(viewModel: container.makeSettingsViewModel(player: localPlayer))
-            }
+            } else {
+                 // SwiftData @Query가 아직 로딩 중이면 players.first가 nil이므로,
+                 // 빈 화면 대신 로고 placeholder를 표시하여 깜빡임 방지.
+                 playerLoadingView
+             }
         case .gameReady(let localPlayer, let remotePlayer, let isNetwork):
             GameReadyView(viewModel: container.makeGameReadyViewModel(localPlayer: localPlayer,
                                                                       remotePlayer: remotePlayer,
@@ -103,6 +115,10 @@ struct RootView: View {
                                            isNetwork: isNetwork),
                     videoManager: container.makeVideoManager(isNetwork: isNetwork)
                 )
+            } else {
+                // SwiftData @Query가 아직 로딩 중이면 players.first가 nil이므로,
+                // 빈 화면 대신 로고 placeholder를 표시하여 깜빡임 방지.
+                playerLoadingView
             }
         case .operationGuide(let local, let remote, let isNetwork):
             OperationGuideView(localPlayer: local,
@@ -122,6 +138,21 @@ struct RootView: View {
 }
 
 extension RootView {
+     /// UserDefaults를 동기적으로 읽어 초기 라우트를 결정한다.
+     /// RootView.init에서 사용하여 첫 프레임부터 올바른 화면을 렌더링한다.
+     private static func initialRootRoute() -> AppRoute {
+        let hasCompletedPermission = UserDefaultsList.Permission.hasCompletedPermissionSetup
+        let hasCompletedProfile = UserDefaultsList.Profile.hasCompletedProfileSetup
+
+        if hasCompletedProfile {
+            return .lobby
+        }
+        if hasCompletedPermission {
+            return .profileSetup
+        }
+        return .permissionSetup
+    }
+
     private func handleScenePhase(_ phase: ScenePhase) async {
         switch phase {
         case .active:
@@ -133,18 +164,22 @@ extension RootView {
         }
     }
 
-    private func checkUserStatus() {
+     /// 앱이 foreground로 돌아올 때 라우트를 재확인한다.
+     /// initialRootRoute()가 init에서 이미 올바른 root를 설정하므로,
+     /// 여기서는 root가 변경된 경우(예: 설정 완료 후)에만 업데이트한다.
+     private func checkUserStatus() {
         guard router.path.isEmpty else { return }
-        
-        let hasCompletedPermission = UserDefaultsList.Permission.hasCompletedPermissionSetup
-        let hasCompletedProfile = UserDefaultsList.Profile.hasCompletedProfileSetup
-        
-        if hasCompletedProfile {
-            router.setRoot(.lobby)
-        } else if hasCompletedPermission {
-            router.setRoot(.profileSetup)
-        } else {
-            router.setRoot(.permissionSetup)
+
+        let desiredRoot = Self.initialRootRoute()
+        guard router.root != desiredRoot else { return }
+        router.setRoot(desiredRoot)
+    }
+
+    /// SwiftData @Query 로딩이 완료되기 전에 표시되는 placeholder.
+    /// players.first가 nil인 동안 빈 화면 대신 이 뷰를 보여준다.
+    private var playerLoadingView: some View {
+        BackgroundContainerView {
+            LoadingPlaceholderView()
         }
     }
 }

--- a/iOS/App/Sources/Presentation/Shared/Components/LoadingPlaceholderView.swift
+++ b/iOS/App/Sources/Presentation/Shared/Components/LoadingPlaceholderView.swift
@@ -1,0 +1,19 @@
+//
+//  LoadingPlaceholderView.swift
+//  App
+//
+
+import SwiftUI
+
+/// 비동기 데이터 로딩 중에 표시되는 공통 placeholder.
+/// 확정되지 않은 상태에서 의미 있는 UI가 잘못 보이는 플리커를 방지하기 위해 사용한다.
+struct LoadingPlaceholderView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            ProgressView()
+                .tint(.white)
+            Spacer()
+        }
+    }
+}

--- a/iOS/Modules/NetworkKit/Sources/ConnectivityMonitor.swift
+++ b/iOS/Modules/NetworkKit/Sources/ConnectivityMonitor.swift
@@ -24,6 +24,14 @@ public final class ConnectivityMonitor: ConnectivityMonitoring, @unchecked Senda
 
     private let monitor: NWPathMonitor
     private let queue: DispatchQueue
+    /// NWPathMonitor의 첫 번째 콜백 수신 여부. 초기 상태(false→false 등)에서도
+    /// 콜백을 반드시 한 번 emit하기 위해 사용한다.
+    /// 이 플래그 없이는 오프라인 상태에서 wasConnected == nowConnected이므로
+    /// onStatusChanged가 호출되지 않아 LobbyViewModel.isConnectivityResolved가
+    /// 영원히 false로 남는 버그가 발생한다.
+    private var didEmitInitialStatus = false
+    /// start()의 중복 호출을 방지하기 위한 플래그.
+    private var isStarted = false
 
     public init() {
         self.monitor = NWPathMonitor()
@@ -35,16 +43,23 @@ public final class ConnectivityMonitor: ConnectivityMonitoring, @unchecked Senda
     }
 
     public func start() {
+        // 여러 곳에서 start()가 호출되어도 NWPathMonitor는 한 번만 시작되도록 보장.
+        guard !isStarted else { return }
+        isStarted = true
         monitor.pathUpdateHandler = { [weak self] path in
             DispatchQueue.main.async {
-                let wasConnected = self?.isConnected ?? false
+                guard let self else { return }
+                let wasConnected = self.isConnected
                 let nowConnected = path.status == .satisfied
-                
-                self?.isConnected = nowConnected
-                self?.connectionType = self?.detectConnectionType(path) ?? .unknown
-                
-                if wasConnected != nowConnected {
-                    self?.onStatusChanged?(nowConnected)
+
+                self.isConnected = nowConnected
+                self.connectionType = self.detectConnectionType(path)
+
+                // 첫 번째 콜백은 상태 변경 여부와 관계없이 무조건 emit한다.
+                // 이후에는 상태가 실제로 변경된 경우에만 emit한다.
+                if !self.didEmitInitialStatus || wasConnected != nowConnected {
+                    self.didEmitInitialStatus = true
+                    self.onStatusChanged?(nowConnected)
                 }
             }
         }


### PR DESCRIPTION
## 증상

앱 실행 시 세 가지 화면 깜빡임이 발생:

1. **PermissionSetupView 플래시** — 이미 권한/프로필 설정을 완료한 사용자가 앱을 실행하면, Lobby 화면 전에 PermissionSetupView가 한 프레임 깜빡임
2. **Local → Remote 전환 플리커** — Wi-Fi 연결 상태에서 Lobby 진입 시, Local 모드 UI가 잠깐 보인 후 Remote 모드로 전환
3. **채널 목록 빈 화면 플래시** — Remote 모드에서 채널 목록 로딩 중 "빈 은하" ChannelEmptyView가 잠깐 표시

세 버그 모두 **"비동기 데이터가 도착하기 전의 초기 상태가 의미 있는 UI로 잘못 해석되는 문제"**라는 공통 패턴.

### AS-IS: UI

| 첫번째 | 두번째 | 세번째 |
| --- | --- | --- |
| <img width="300" alt="first-flicker-view" src="https://github.com/user-attachments/assets/4fa96a7d-f399-47bc-aebf-0b275f3120b0" /> | <img width="300" alt="second-flicker-view" src="https://github.com/user-attachments/assets/822f0eb4-b69b-40f5-86ae-bf0514638980" /> | <img width="300" alt="third-flicker-view" src="https://github.com/user-attachments/assets/da69be8d-e4f7-482d-aaa9-ac2971aad8c9" /> |

### AS-IS: VIDEO

https://github.com/user-attachments/assets/f5045b6c-6a82-487d-bf8d-8f8053153941

### TO-BE:


https://github.com/user-attachments/assets/4adeaa7d-9757-4be9-8a3c-e7e109f92abb

## 원인 및 수정

### 1. Root 라우팅 플리커 (`RootView.swift`)

| 원인 | 수정 |
|------|------|
| `AppRouter` 기본값이 `.permissionSetup` | `initialRootRoute()`로 UserDefaults를 **동기적**으로 읽어 init 시점에 올바른 초기 라우트 결정 |
| `.task`에서 비동기 `checkUserStatus()` 호출 → 첫 프레임은 이미 `.permissionSetup`으로 렌더링 완료 | `RootView.init`에서 즉시 올바른 라우트 설정, `checkUserStatus()`는 방어적 역할로 변경 |
| SwiftData `@Query` 로딩 전 `players.first`가 nil → 빈 화면 | `playerLoadingView` placeholder 추가 (3곳) |

### 2. Lobby 콘텐츠 플리커 (`LobbyViewModel.swift`, `LobbyView.swift`, `ConnectivityMonitor.swift`)

| 원인 | 수정 |
|------|------|
| `ConnectivityMonitor.isConnected` 초기값 `false` → `networkMode = .local`로 첫 프레임 렌더링 | `isConnectivityResolved` 플래그 추가, resolved 전에는 중립적 placeholder 표시 |
| `ConnectivityMonitor`가 초기 상태를 emit 안 함 (오프라인일 때 `false→false`로 변경 없어 콜백 미호출) | `didEmitInitialStatus` 플래그로 첫 상태 무조건 emit 보장 |
| `setup()`에서 `setupExploration()` 직접 호출 → connectivity 확정 전에 탐색 시작 | `setup()`에서 제거, `handleConnectivityChange()` 콜백에서만 호출 |
| SwiftUI `onAppear`가 여러 번 호출되어 `setup()` 중복 실행 | `didSetup` 플래그로 1회만 실행 보장, `ConnectivityMonitor.isStarted`로 중복 start 방지 |

### 3. 채널 목록 빈 화면 플래시 (`ChannelListViewModel.swift`, `LobbyView.swift`)

| 원인 | 수정 |
|------|------|
| `channels = []` 초기값이 "로딩 중"인지 "정말 없는 것"인지 구분 불가 | `LoadState` enum (`idle`/`loading`/`loaded`/`failed`) 도입 |
| 로딩 중에도 `channels.isEmpty` → `ChannelEmptyView` 표시 | `idle`/`loading` → placeholder, `loaded` → 실제 목록 or 빈 화면, `failed` → 재시도 버튼 |
| `onChange(of: networkMode)`만으로는 이미 remote인 경우 fetch 미호출 | `onAppear`에서도 `fetchChannels()` 호출 추가 |

## 수정 전략 요약

> **확정되지 않은 상태에서는 중립적인 placeholder를 보여주고, 상태가 확정된 후에만 의미 있는 UI를 렌더링한다.**

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `RootView.swift` | `initialRootRoute()` 동기 초기화 + `playerLoadingView` placeholder |
| `LobbyView.swift` | `isConnectivityResolved` 게이트 + `LoadState` 기반 채널 목록 렌더링 |
| `LobbyViewModel.swift` | `isConnectivityResolved`, `didSetup` 플래그 + `setup()` 흐름 정리 |
| `ChannelListViewModel.swift` | `LoadState` enum 도입 + fetch 상태 관리 |
| `ConnectivityMonitor.swift` | `didEmitInitialStatus` 초기 emit 보장 + `isStarted` 중복 방지 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connectivity-aware neutral loading placeholders before network resolution.
  * Load-state driven channel list with loading, empty, error views and a retry action.
  * Initial-route and player-logo loading placeholders to avoid blank screens on startup.

* **Bug Fixes**
  * Eliminates UI flicker during startup and connectivity transitions.
  * Prevents redundant connectivity/startup signals and redundant lifecycle-triggered fetches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->