### PR TITLE
fix: xcconfig 생성 시 bash $() 명령어 치환 방지

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,10 @@ jobs:
         run: tuist install
 
       - name: Create Environment.xcconfig
-        run: echo "${{ secrets.XCCONFIG_CONTENT }}" > iOS/App/Environment.xcconfig
+        run: |
+          cat <<'EOF' > iOS/App/Environment.xcconfig
+          ${{ secrets.XCCONFIG_CONTENT }}
+          EOF
 
       - name: Generate Project
         run: tuist generate --no-open

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -25,7 +25,10 @@ jobs:
         run: mise exec -- tuist version
 
       - name: Create Environment.xcconfig
-        run: echo "${{ secrets.XCCONFIG_CONTENT }}" > iOS/App/Environment.xcconfig
+        run: |
+          cat <<'EOF' > iOS/App/Environment.xcconfig
+          ${{ secrets.XCCONFIG_CONTENT }}
+          EOF
 
       - name: Install Ruby Dependencies
         run: bundle install


### PR DESCRIPTION
## Summary
- CI 워크플로우에서 `echo` 쌍따옴표 안의 `$()` 가 bash 명령어 치환으로 해석되어 xcconfig 이스케이핑이 소실되는 문제 수정
- `cat <<'EOF'` heredoc으로 변경하여 `$()` 리터럴 보존
- TestFlight 빌드에서 서버 URL이 `http:` 로 잘려 서버 통신 불가했던 원인

## Changed Files
- `.github/workflows/deploy-testflight.yml`
- `.github/workflows/build_test.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration file handling in build and deployment workflows to better support multi-line content, enhancing the reliability of the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->