### PR TITLE
[DEV-133] iphone만 지원하도록 수정

### DIFF
--- a/iOS/App/Project.swift
+++ b/iOS/App/Project.swift
@@ -48,13 +48,6 @@ let project = Project(
 
                 "UISupportedInterfaceOrientations": .array([
                     .string("UIInterfaceOrientationPortrait"),
-                ]),
-
-                "UISupportedInterfaceOrientations~ipad": .array([
-                    .string("UIInterfaceOrientationPortrait"),
-                    .string("UIInterfaceOrientationPortraitUpsideDown"),
-                    .string("UIInterfaceOrientationLandscapeLeft"),
-                    .string("UIInterfaceOrientationLandscapeRight"),
                 ])
             ]),
             sources: [


### PR DESCRIPTION
## 요약
- iphone만 지원하도록 설정 변경

### 작업 목록
- [ ] iphone만 지원하도록 설정 변경

closes DEV-133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * iPad app now restricted to portrait orientation only; landscape and upside-down orientations are no longer supported. iPhone orientation support remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->