### PR TITLE
[DEV-136] NetworkChannelPlayerListDTO 디코딩 실패 처리

### DIFF
--- a/backend/Sources/App/Game/GameMessageHandler.swift
+++ b/backend/Sources/App/Game/GameMessageHandler.swift
@@ -1,6 +1,10 @@
 import Vapor
 
 final class GameMessageHandler: WSMessageHandler, Sendable {
+    
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
     func handle(_ message: WSMessage, from session: WSSession, manager: WSSessionManager) async {
         guard let type = GameMessageType(rawValue: message.type) else { return }
 
@@ -34,28 +38,22 @@ final class GameMessageHandler: WSMessageHandler, Sendable {
         }
     }
 
-    private func handleChannelJoin(session: WSSession, manager: WSSessionManager) async {
+    // MARK: - Core Handlers
+
+    func handleChannelJoin(session: WSSession, manager: WSSessionManager) async {
         guard let channelId = session.metadata["channelId"] else { return }
 
         _ = await ChannelManager.shared.join(channelId, session: session)
 
-        let latency = await manager.getLatency(for: session.id)
-        let playerInfoDict = buildPlayerInfo(from: session, latency: latency)
-        
-        guard let playerInfoData = try? JSONSerialization.data(withJSONObject: playerInfoDict),
-              let playerInfo = String(data: playerInfoData, encoding: .utf8) else {
-            print("[GameMessageHandler] \(session.id)의 플레이어 정보를 인코딩하는 데 실패했습니다.")
-            return
+        let playerInfo = await getPlayerInfo(from: session, manager: manager)
+        if let payload = try? encoder.encodeAsString(playerInfo) {
+            let joinedMessage = WSMessage(
+                type: GameMessageType.playerJoined.rawValue,
+                senderId: session.id,
+                payload: payload
+            )
+            await ChannelManager.shared.broadcastToChannel(channelId, message: joinedMessage, exclude: session.id)
         }
-        
-        let joinedMessage = WSMessage(
-            type: GameMessageType.playerJoined.rawValue,
-            senderId: session.id,
-            payload: playerInfo
-        )
-        
-        /// 채널에 있는 다른 플레이어에게 새로운 플레이어가 입장했음을 알림
-        await ChannelManager.shared.broadcastToChannel(channelId, message: joinedMessage, exclude: session.id)
 
         await sendPlayerList(in: channelId, to: session, manager: manager)
     }
@@ -69,8 +67,6 @@ final class GameMessageHandler: WSMessageHandler, Sendable {
             type: GameMessageType.playerLeft.rawValue,
             senderId: session.id
         )
-        
-        /// 채널에 있는 다른 플레이어에게 새로운 플레이어가 퇴장했음을 알림
         await ChannelManager.shared.broadcastToChannel(channelId, message: leftMessage, exclude: session.id)
     }
 
@@ -78,33 +74,28 @@ final class GameMessageHandler: WSMessageHandler, Sendable {
         let sessionsInChannel = await ChannelManager.shared.getSessionsInChannel(channelId)
         guard !sessionsInChannel.isEmpty else { return }
 
-        // 모든 플레이어 정보 수집
-        var playerInfos: [[String: Any]] = []
+        var allPlayers: [PlayerInfo] = []
         for session in sessionsInChannel {
-            let latency = await manager.getLatency(for: session.id)
-            let playerInfo = buildPlayerInfo(from: session, latency: latency)
-            playerInfos.append(playerInfo)
+            allPlayers.append(await getPlayerInfo(from: session, manager: manager))
         }
 
-        // 전송할 세션 목록 결정
         let sessionsToSend = toSession.map { [$0] } ?? sessionsInChannel
 
-        // 각 세션에 플레이어 목록 전송
         for session in sessionsToSend {
-            guard let payload = buildPlayerListPayload(youSessionId: session.id,
-                                                        players: playerInfos) else {
-                print("[GameMessageHandler] \(session.id) 세션의 플레이어 목록을 구성하는 데 실패했습니다.")
-                continue
-            }
+            let payloadObj = PlayerListPayload(youSessionId: session.id, players: allPlayers)
 
-            let listMessage = WSMessage(
-                type: GameMessageType.channelPlayerList.rawValue,
-                senderId: "server",
-                payload: payload
-            )
-            await manager.send(to: session.id, message: listMessage)
+            if let payloadString = try? encoder.encodeAsString(payloadObj) {
+                let listMessage = WSMessage(
+                    type: GameMessageType.channelPlayerList.rawValue,
+                    senderId: "server",
+                    payload: payloadString
+                )
+                await manager.send(to: session.id, message: listMessage)
+            }
         }
     }
+
+    // MARK: - Forwarding
 
     private func forwardToTarget(message: WSMessage, from session: WSSession, manager: WSSessionManager) async {
         guard let targetId = message.payload else { return }
@@ -117,11 +108,9 @@ final class GameMessageHandler: WSMessageHandler, Sendable {
     }
 
     private func handleForwarding(message: WSMessage, from session: WSSession, manager: WSSessionManager) async {
-        guard let channelId = session.metadata["channelId"] else { return }
-
-        guard let payload = message.payload,
-              let data = payload.data(using: .utf8),
-              let routed = try? JSONDecoder().decode(ForwardingPayload.self, from: data) else {
+        guard let channelId = session.metadata["channelId"],
+              let payloadData = message.payload?.data(using: .utf8),
+              let routed = try? decoder.decode(ForwardingPayload.self, from: payloadData) else {
             return
         }
 
@@ -136,30 +125,28 @@ final class GameMessageHandler: WSMessageHandler, Sendable {
         await manager.send(to: routed.to, message: forwarded)
     }
 
-    private func buildPlayerInfo(from session: WSSession, latency: Double?) -> [String: Any] {
-        let nickname = session.metadata["nickname"] ?? "unknown"
-        let character = session.metadata["character"] ?? ""
-        let lat = latency ?? 200.0
+    // MARK: - Helpers
 
-        return [
-            "sessionId": session.id,
-            "nickname": nickname,
-            "characterRawValue": character,
-            "latency": lat
-        ]
+    /// 세션 메타데이터와 Latency를 기반으로 PlayerInfo 객체 생성.
+    private func getPlayerInfo(from session: WSSession, manager: WSSessionManager) async -> PlayerInfo {
+        let latency = await manager.getLatency(for: session.id)
+        return PlayerInfo(
+            sessionId: session.id,
+            nickname: session.metadata["nickname"] ?? "unknown",
+            characterRawValue: session.metadata["character"] ?? "",
+            latency: latency ?? 200.0
+        )
     }
+}
 
-    private func buildPlayerListPayload(youSessionId: String, players: [[String: Any]]) -> String? {
-        let payloadDict: [String: Any] = [
-            "youSessionId": youSessionId,
-            "players": players
-        ]
+// MARK: - JSONEncoder Extension
 
-        guard let payloadData = try? JSONSerialization.data(withJSONObject: payloadDict),
-              let payload = String(data: payloadData, encoding: .utf8) else {
-            return nil
+extension JSONEncoder {
+    func encodeAsString<T: Encodable>(_ value: T) throws -> String {
+        let data = try self.encode(value)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw EncodingError.invalidValue(value, .init(codingPath: [], debugDescription: "Failed to convert encoded data to UTF-8 string"))
         }
-
-        return payload
+        return string
     }
 }

--- a/backend/Sources/App/WebSocket/Models/Players.swift
+++ b/backend/Sources/App/WebSocket/Models/Players.swift
@@ -1,0 +1,22 @@
+//
+//  Players.swift
+//  backend
+//
+//  Created by 강윤서 on 2/5/26.
+//
+
+import Foundation
+
+/// 플레이어 개별 정보
+struct PlayerInfo: Codable {
+    let sessionId: String
+    let nickname: String
+    let characterRawValue: String
+    let latency: Double
+}
+
+/// 채널 내 플레이어 목록 응답 데이터
+struct PlayerListPayload: Codable {
+    let youSessionId: String
+    let players: [PlayerInfo]
+}


### PR DESCRIPTION
## 요약
`GameMessageHandler`에서 플레이어 정보를 JSON으로 직렬화할 때 발생하던 **이중 인코딩 버그**를 수정하고, 데이터 모델링을 `Codable` 구조체 기반으로 개선했습니다.

## 작업 목록
- [x] JSON 이중 인코딩으로 인한 iOS 디코딩 실패 버그 수정
- [x] `[String: Any]` 딕셔너리 → `Codable` 구조체 전환
- [x] `PlayerInfo`, `PlayerListPayload` DTO 모델 추가
- [x] `JSONEncoder`/`JSONDecoder` 인스턴스 재사용 구조 도입
- [x] `JSONEncoder.encodeAsString()` 유틸리티 익스텐션 추가
- [x] `sendPlayerList` 내 중복 분기 로직 통합

## 작업 내용 상세
### 1. 기존 문제점
`buildPlayerInfo()`가 JSON 문자열(`String`)을 반환하고 있었습니다.

```swift
// AS-IS: buildPlayerInfo()가 JSON 문자열을 직접 반환
private func buildPlayerInfo(from session: WSSession, latency: Double?) -> String {
    guard let data = try? JSONSerialization.data(withJSONObject: dict),
          let json = String(data: data, encoding: .utf8) else {
        return "{\"sessionId\":\"\(session.id)\", ...}"  // 폴백도 문자열 보간
    }
    return json
}
```

이 문자열들을 다시 문자열 연결로 배열/객체 JSON을 조립했습니다.
```swift
let playersArray = "[" + playerInfos.joined(separator: ",") + "]"
let payload = "{\"youSessionId\":\"\(session.id)\",\"players\":\(playersArray)}"
```

이렇게 만든 payload(이미 JSON 문자열)가 `WSMessage.payload`에 담긴 뒤 `WSMessage.encode()` 시점에 한 번 더 인코딩되면서 따옴표가 이스케이프(`\"`)되는 이중 인코딩 문제가 발생했습니다.

**결과적으로 iOS 클라이언트의 `NetworkChannelPlayerListDTO` 디코딩이 실패했습니다.**

### 2. 첫 번째 수정 (2eec95d)

`buildPlayerInfo()`의 반환 타입을 `String` → `[String: Any]` 딕셔너리로 변경하고, `JSONSerialization`으로 정확한 JSON을 생성하도록 수정했습니다.

- `buildPlayerInfo()` → 딕셔너리 반환
- `JSONSerialization.data(withJSONObject:)`로 올바른 JSON 생성
- 문자열 보간 기반 JSON 조립 제거
- 이중 인코딩 문제 해결

### 3. 두 번째 수정 (9c44b81)

딕셔너리 기반 접근을 `Codable` 구조체로 전면 교체하여 타입 안전성, 가독성, 성능을 모두 개선했습니다.

#### 모델 추가 (`Players.swift`)

```swift
struct PlayerInfo: Codable {
    let sessionId: String
    let nickname: String
    let characterRawValue: String
    let latency: Double
}

struct PlayerListPayload: Codable {
    let youSessionId: String
    let players: [PlayerInfo]
}
```

#### 주요 변경 사항

| 항목 | Before | After |
|------|--------|------|
| 데이터 표현 | `[String: Any]` 딕셔너리 | `Codable` 구조체 |
| 직렬화 | `JSONSerialization` (매 호출 생성) | `JSONEncoder` 인스턴스 재사용 |
| 역직렬화 | `JSONDecoder()` 매번 생성 | `JSONDecoder` 인스턴스 재사용 |
| 플레이어 목록 전송 | `toSession` 유무에 따라 `if/else` 분기 | `toSession.map { [$0] } ?? sessionsInChannel`로 통합 |
| TaskGroup | `withTaskGroup`으로 병렬 수집 후 문자열 `join` | 순차 `for` 루프로 `[PlayerInfo]` 배열 구성 |

### 참고 사항

- `WSMessage.payload`는 `String?` 타입이므로, `Codable` 객체를 `JSONEncoder.encodeAsString()`으로 변환하여 전달합니다.
- `sendPlayerList`의 `withTaskGroup` 병렬 처리를 다시 for문으로 롤백했습니다.
    - `getLatency` 호출이 경량 연산이라 병렬화 오버헤드 대비 이점이 없다고 하네요..ㅎㅎ
- `handleChannelJoin`, `sendPlayerList`의 접근 제어자를 `func`(internal)으로 변경하여 테스트 가능하도록 했습니다.