### PR TITLE
[DEV-137] 게임뷰 메뉴 오버레이 로직 복구

### DIFF
--- a/iOS/App/Sources/Presentation/Game/View/GameView.swift
+++ b/iOS/App/Sources/Presentation/Game/View/GameView.swift
@@ -67,6 +67,11 @@ struct GameView: View {
             facePreviewOverlay
                 .zIndex(1)
 
+            if isMenuPresented {
+                menuOverlay
+                    .zIndex(10)
+            }
+            
             if let reason = viewModel.endReason {
                 gameEndOverlay(reason: reason)
                     .zIndex(10)


### PR DESCRIPTION
## 요약
게임 진행 중 메뉴 오버레이가 정상적으로 최상단에 표시되지 않던 문제를 수정했습니다.

## 변경 내용
- `GameView`에서 `isMenuPresented` 조건부로 `menuOverlay` 추가
- `zIndex(10)`을 적용해 다른 오버레이(프리뷰, 종료 화면 등) 위에 표시되도록 조정

## 참고사항
앞선 PR에서 처리가 되어 닫았습니다

closes dev-137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved menu overlay layering system to ensure the menu interface displays above other content elements with enhanced visual hierarchy and interaction priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->