### PR TITLE
[DEV-139] LobbyView UI 기기 대응

### DIFF
--- a/iOS/App/Sources/Presentation/Lobby/Components/ChannelEmptyView.swift
+++ b/iOS/App/Sources/Presentation/Lobby/Components/ChannelEmptyView.swift
@@ -34,7 +34,7 @@ struct ChannelEmptyView: View {
                 .frame(width: 88, height: 106)
                 .padding(.top, -30)
         }
-        .padding(.top, 77)
+        .padding(.top, 30)
     }
 }
 

--- a/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
+++ b/iOS/App/Sources/Presentation/Lobby/LobbyView.swift
@@ -30,9 +30,6 @@ struct LobbyView: View {
             .ignoresSafeArea()
 
             VStack(spacing: 0) {
-                topBar
-                    .padding(.horizontal, 20)
-
                 // ConnectivityMonitor의 첫 번째 콜백이 오기 전까지 networkMode가 확정되지 않으므로,
                 // resolved 전에는 중립적 placeholder를 표시하여 local↔remote 전환 깜빡임을 방지.
                 if !viewModel.isConnectivityResolved {
@@ -43,6 +40,10 @@ struct LobbyView: View {
                     lobbyContent
                 }
             }
+        }
+        .safeAreaInset(edge: .top) {
+            topBar
+                .padding(.horizontal, 20)
         }
         .onAppear {
             viewModel.setup()


### PR DESCRIPTION
## 요약
- LobbyView UI 기기 대응을 위해 고정된 height를 제거하고 통일된 UI로 보일 수 있게 하였습니다. 
<br/>

### 작업 목록
- [X] LobbyView UI 기기대응
<br/>

## 작업 내용
### LobbyView UI 기기대응
- `ZStack` 으로 `BackgroundContainerView` 감싸고 배경만 화면 끝까지 꽉 차게 `ignoresSafeArea` 추가
- `playerOrbitSelector` `고정 height` 삭제, `vertical padding` 추가
- `greetingCard` `font size` 하향 조정
- 하단 `button padding` 하향 조정
- `ChannelEmptyView` `top padding` 하향 조정
- `LobbyView` `topBar` `safeAreaInset`으로 변경
<br/>

### UI 변경 
- iPad Air 11-inch<br/>
<img width="400" height="880" alt="Simulator Screenshot - iPad Air 11-inch (M3) - 2026-02-09 at 22 29 12" src="https://github.com/user-attachments/assets/5544bf62-de32-422e-aa35-bc07d9918c01" /><img width="400" height="880" alt="Simulator Screenshot - iPad Air 11-inch (M3) - 2026-02-10 at 17 45 43" src="https://github.com/user-attachments/assets/ed56fb53-f0f7-4f4b-be82-62992178787a" /><br/><br/>

- iPhone SE<br/>
<img width="200" height="440" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-02-09 at 23 41 39" src="https://github.com/user-attachments/assets/b719b64f-f9ec-4c0b-b080-a6db8c293379" />
<img width="200" height="440" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-02-10 at 17 45 49" src="https://github.com/user-attachments/assets/cfbaa828-c2c1-4166-a1f1-39ae0ad245a1" /><br/><br/>

- iPhone 17<br/>
<img width="200" height="440" alt="Simulator Screenshot - iPhone 17 - 2026-02-09 at 22 28 48" src="https://github.com/user-attachments/assets/dfe52096-f105-4e9e-8526-4cb01869f30f" />
<img width="200" height="440" alt="Simulator Screenshot - iPhone 17 - 2026-02-10 at 17 45 38" src="https://github.com/user-attachments/assets/41c38bfa-96ef-4c82-b256-1993c9a0c127" /><br/><br/>

- iPhone 12 mini<br/>
<img width="200" height="440" alt="IMG_9528" src="https://github.com/user-attachments/assets/c4546c77-f7bf-4e21-830d-64048f598b44" />
<img width="200" height="440" alt="IMG_9547" src="https://github.com/user-attachments/assets/21e02827-1abc-4df7-a625-79bcb75e14c2" /><br/><br/>

refs DEV-139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined lobby screen layout with improved spacing and reduced vertical gaps.
  * Moved top bar into the safe area and adjusted horizontal padding for consistent alignment.
  * Reduced greeting text sizes for better visual balance.
  * Made the player area dynamically sized for improved responsiveness.
  * Decreased bottom button padding and tightened channel-empty view spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->