### PR TITLE
[DEV-124] 요청중이거나 거절 모달이 띄워진 유저에게는 초대가 안되는 이슈 해결

### DIFF
--- a/iOS/App/Sources/Presentation/Lobby/Model/GameMatchStatus.swift
+++ b/iOS/App/Sources/Presentation/Lobby/Model/GameMatchStatus.swift
@@ -45,7 +45,8 @@ enum GameMatchStatus: Equatable {
             self = .requestDeclined(player: player)
 
         case (.idle, .receiveInvite(let player, let wasSoloGame)),
-             (.soloGame, .receiveInvite(let player, let wasSoloGame)):
+             (.soloGame, .receiveInvite(let player, let wasSoloGame)),
+             (.requestDeclined, .receiveInvite(let player, let wasSoloGame)):
             self = .receivedInvite(player: player, wasSoloGame: wasSoloGame)
 
         case (.receivedInvite(let player, _), .acceptInvite):


### PR DESCRIPTION
## 요약
- 요청중이거나 거절 모달이 띄워진 유저에게는 초대가 안되는 이슈를 해결했습니다.

### 작업 목록
- [X] GameMatchStatus requestDevlined 상태에서 receivedInvite event를 받을 때 case 추가
<br/>

## 작업 내용
- 초대 요청도 오고 상단 알림 리스트에도 쌓이나 UI 상 교체가 되지 않는 문제임을 파악.
- 알림 리스트에 쌓이는지 확인.
- GameMatchStatus requestDevlined 상태에서 receivedInvite event를 받을 때 case 추가
<br/>

### UI 변경 
![ScreenRecording_02-13-202615-55-51_1-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ff3a7aab-982a-44e8-a736-f7bb5ba844b2)
- 초대 후 거절 모달 띄워진 상태에서 초대 받으면 다시 초대 bottomSheet 가 올라옴.
- 초대 bottomSheet가 올라와진 상태에서 전혀 다른 제 3자가 초대를 보내면 알림 리스트 UI로 확인 가능
<br/>

closes DEV-124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the game invitation system to ensure users can reliably receive and respond to new game invitations across all game states. The app now correctly handles invitation requests even when a previous invitation was declined. Game state consistency is properly maintained, allowing for seamless gameplay transitions and preventing invitation delivery issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->