### PR TITLE
[DEV-74] 스냅샷 보정 기능 구현

### DIFF
--- a/iOS/App/Sources/Presentation/Game/GameplayIO/MultiplayerNetworkIO.swift
+++ b/iOS/App/Sources/Presentation/Game/GameplayIO/MultiplayerNetworkIO.swift
@@ -39,12 +39,17 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
 
     /// 움직임 변화가 작으면 전송 생략(네트워크/지터 최적화)
     private let movementSendThreshold: Double = 0.02
+    /// 위치가 이 값 이상 변하면 keep-alive를 기다리지 않고 즉시 동기화
+    private let positionSendThreshold: Double = 8.0
     private var timeSinceLastMovementSend: TimeInterval = 0
     /// 동일 값 유지 시에도 liveness 보장을 위한 keep-alive 주기
     private let movementKeepAliveInterval: TimeInterval = 0.4
     
     private var lastSentMoveX: Double = 0
+    private var lastSentPosition: CharacterPosition = .zero
     private var pendingLocalMoveX: Double = 0
+    private var localJumpSequence: Int = 0
+    private var lastRemoteJumpSequence: Int = -1
 
     // --- Receive + interpolation ---
     private var remoteTargetMoveX: Double = 0
@@ -71,7 +76,8 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
     private let remoteFreezeAfter: TimeInterval = 0.8
 
     /// 이 시간 이상 원격 수신이 없으면 연결 끊김으로 판단
-    private let peerTimeoutInterval: TimeInterval = 10.0
+    /// (실제 네트워크 끊김 콜백 외에 입력 무수신 기반 보조 판단)
+    private let peerTimeoutInterval: TimeInterval = 20.0
     private var didNotifyPeerTimeout: Bool = false
 
     init(
@@ -134,7 +140,10 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
         movementSendAccumulator = 0
         timeSinceLastMovementSend = 0
         lastSentMoveX = 0
+        lastSentPosition = .zero
         pendingLocalMoveX = 0
+        localJumpSequence = 0
+        lastRemoteJumpSequence = -1
         remoteTargetMoveX = 0
         remoteSmoothedMoveX = 0
         lastRemoteReceivedAt = Date().timeIntervalSince1970
@@ -215,13 +224,39 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
             return
         }
 
+        // 입력 종류와 무관하게 "상대 생존 신호"로 간주
+        self.lastRemoteReceivedAt = Date().timeIntervalSince1970
+        self.didForceStopRemote = false
+        self.didNotifyPeerTimeout = false
+
         switch dto.kind {
         case .horizontal:
             let x = Double(dto.x ?? 0)
-            self.lastRemoteReceivedAt = Date().timeIntervalSince1970
-            self.didForceStopRemote = false
             self.remoteTargetMoveX = x
+
+            if let px = dto.positionX, let py = dto.positionY {
+                let position = CharacterPosition(x: px, y: py)
+                await MainActor.run {
+                    self.gameplayManager.updatePosition(position, for: remotePlayerID)
+                }
+            }
         case .jumpTriggered:
+            if let seq = dto.jumpSeq {
+                guard seq > self.lastRemoteJumpSequence else { return }
+                self.lastRemoteJumpSequence = seq
+            }
+
+            if let x = dto.x {
+                self.remoteTargetMoveX = x
+            }
+
+            if let px = dto.positionX, let py = dto.positionY {
+                let position = CharacterPosition(x: px, y: py)
+                await MainActor.run {
+                    self.gameplayManager.updatePosition(position, for: remotePlayerID)
+                }
+            }
+
             await MainActor.run {
                 self.gameplayManager.applyJumpTriggered(for: remotePlayerID)
             }
@@ -232,7 +267,7 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
                   let reason = self.decodeRespawnReason(raw) else {
                 return
             }
-            let pos = RespawnPosition(x: x, y: y)
+            let pos = CharacterPosition(x: x, y: y)
             await MainActor.run {
                 self.gameplayManager.applyRespawnRequested(reason, position: pos, for: remotePlayerID)
             }
@@ -275,7 +310,7 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
         }
     }
 
-    private func handleLocalRespawnConfirmed(playerID: UUID, reason: RespawnReason, position: RespawnPosition) async {
+    private func handleLocalRespawnConfirmed(playerID: UUID, reason: RespawnReason, position: CharacterPosition) async {
         guard playerID == self.localPlayerID else { return }
         guard let peerId = self.peerId else { return }
 
@@ -403,7 +438,33 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
     private func handleLocalJumpTriggered(playerID: UUID) async {
         guard playerID == self.localPlayerID else { return }
         guard let peerId = self.peerId else { return }
-        self.sendDTO(.jumpTriggered, to: peerId)
+
+        let fallbackMoveX = pendingLocalMoveX
+        let localID = localPlayerID
+        let (currentMoveX, currentPosition) = await MainActor.run {
+            let character = gameplayManager.state.characters[localID]
+            return (character?.moveX ?? fallbackMoveX, character?.position ?? .zero)
+        }
+
+        let quantizedMoveX = quantize(currentMoveX, step: 0.01)
+        let quantizedPosition = CharacterPosition(
+            x: quantize(currentPosition.x, step: 1.0),
+            y: quantize(currentPosition.y, step: 1.0)
+        )
+
+        localJumpSequence += 1
+        let jumpDTO = NetworkGameInputDTO.jumpTriggered(
+            moveX: quantizedMoveX,
+            positionX: quantizedPosition.x,
+            positionY: quantizedPosition.y,
+            jumpSeq: localJumpSequence
+        )
+        self.sendDTO(jumpDTO, to: peerId)
+
+        // 점프 스냅샷도 최근 전송 상태로 반영해 중복 전송을 줄인다.
+        lastSentMoveX = quantizedMoveX
+        lastSentPosition = quantizedPosition
+        timeSinceLastMovementSend = 0
     }
 
     // MARK: - Tick send + smoothing
@@ -417,23 +478,37 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
         movementSendAccumulator -= movementSendInterval
 
         // 스냅샷 소스는 "현재 캐릭터 상태" 기반이 더 일관적(입력 지터 방지)
-        let fallback = pendingLocalMoveX
+        let fallbackMoveX = pendingLocalMoveX
         let localID = localPlayerID
-        let currentMoveX = await MainActor.run {
-            gameplayManager.state.characters[localID]?.moveX ?? fallback
+        let (currentMoveX, currentPosition) = await MainActor.run {
+            let character = gameplayManager.state.characters[localID]
+            return (character?.moveX ?? fallbackMoveX, character?.position ?? .zero)
         }
 
         // 간단 quantize(페이로드 안정화)
-        let quantized = (currentMoveX * 100).rounded() / 100
+        let quantizedMoveX = quantize(currentMoveX, step: 0.01)
+        let quantizedPosition = CharacterPosition(
+            x: quantize(currentPosition.x, step: 1.0),
+            y: quantize(currentPosition.y, step: 1.0)
+        )
         
-        let hasSignificantChange = abs(quantized - lastSentMoveX) >= movementSendThreshold
+        let hasSignificantMoveChange = abs(quantizedMoveX - lastSentMoveX) >= movementSendThreshold
+        let hasSignificantPositionChange = distance(quantizedPosition, lastSentPosition) >= positionSendThreshold
         let isKeepAliveDue = timeSinceLastMovementSend >= movementKeepAliveInterval
-        guard hasSignificantChange || isKeepAliveDue else { return }
+        guard hasSignificantMoveChange || hasSignificantPositionChange || isKeepAliveDue else { return }
         
         // 전송 성공 기준으로 reset
         timeSinceLastMovementSend = 0
-        lastSentMoveX = quantized
-        sendDTO(.horizontal(quantized), to: peerId)
+        lastSentMoveX = quantizedMoveX
+        lastSentPosition = quantizedPosition
+        sendDTO(
+            .horizontal(
+                quantizedMoveX,
+                positionX: quantizedPosition.x,
+                positionY: quantizedPosition.y
+            ),
+            to: peerId
+        )
     }
 
     private func updateRemoteInterpolation(deltaTime: TimeInterval) async {
@@ -464,5 +539,13 @@ actor MultiplayerNetworkIO: MultiplayerNetworkManaging {
 
     private func sendDTO(_ dto: NetworkGameInputDTO, to peerId: UUID) {
         connectionSessionManager.sendGameData(dto, to: peerId)
+    }
+
+    private func quantize(_ value: Double, step: Double) -> Double {
+        (value / step).rounded() * step
+    }
+
+    private func distance(_ lhs: CharacterPosition, _ rhs: CharacterPosition) -> Double {
+        hypot(lhs.x - rhs.x, lhs.y - rhs.y)
     }
 }

--- a/iOS/App/Sources/Presentation/Game/Scene/Controller/CharacterController.swift
+++ b/iOS/App/Sources/Presentation/Game/Scene/Controller/CharacterController.swift
@@ -168,11 +168,17 @@ final class CharacterController {
     
     func applyMovement(deltaTime: TimeInterval,
                        moveX: Double,
-                       isGrounded: Bool
+                       isGrounded: Bool,
+                       targetPosition: CGPoint? = nil
     ) {
         guard let physicsCore else { return }
         
-        physicsCore.applyState(deltaTime: deltaTime, moveX: moveX, isGrounded: isGrounded)
+        physicsCore.applyState(
+            deltaTime: deltaTime,
+            moveX: moveX,
+            isGrounded: isGrounded,
+            targetPosition: (playerRole == .remote ? targetPosition : nil)
+        )
         
         animatePlayer(moveX: moveX)
         syncRespawnLabelPosition()

--- a/iOS/App/Sources/Presentation/Game/Scene/GameScene.swift
+++ b/iOS/App/Sources/Presentation/Game/Scene/GameScene.swift
@@ -26,6 +26,10 @@ final class GameScene: SKScene {
     
     private let outOfBoundsMargin: CGFloat = 100
     private var lastUpdateTime: TimeInterval = 0
+    private var localPositionSyncAccumulator: TimeInterval = 0
+    private var lastSyncedLocalPosition: CharacterPosition?
+    private let localPositionSyncInterval: TimeInterval = 1.0 / 15.0
+    private let localPositionSyncMinDistance: Double = 1.0
 
     private var goalPlatformIndex: Int
 
@@ -96,6 +100,10 @@ final class GameScene: SKScene {
             // 카메라가 로컬 플레이어를 따라가도록 설정
             cameraSystem.follow(player)
         }
+
+        if let gameplayManager {
+            syncLocalPlayerPositionToGameState(gameplayManager: gameplayManager, deltaTime: 0, force: true)
+        }
         
         // 몬스터 설정
         monsterController = MonsterController(scene: self, cameraSystem: cameraSystem)
@@ -128,20 +136,9 @@ final class GameScene: SKScene {
         }
 
         // 모든 플레이어의 상태를 반영
-        for (id, controller) in characterControllers {
-            guard let cs = gameplayManager.state.characters[id] else { continue }
+        applyCharacterStates(deltaTime: deltaTime, gameplayManager: gameplayManager)
 
-            controller.applyMovement(
-                deltaTime: deltaTime,
-                moveX: cs.moveX,
-                isGrounded: cs.isGrounded
-            )
-
-            if gameplayManager.isJumpRequested(for: id) {
-                controller.applyJump()
-                gameplayManager.resetJumpRequest(for: id)
-            }
-        }
+        syncLocalPlayerPositionToGameState(gameplayManager: gameplayManager, deltaTime: deltaTime)
         // 맵 업데이트
         updateWalls()
         
@@ -169,6 +166,29 @@ final class GameScene: SKScene {
         
         // 상대 플레이어 화면 좌표 업데이트
         updateRemotePlayerScreenPosition()
+    }
+
+    private func applyCharacterStates(deltaTime: TimeInterval, gameplayManager: GameplayManager) {
+        for (id, controller) in characterControllers {
+            guard let state = gameplayManager.state.characters[id] else { continue }
+
+            let targetPosition: CGPoint? = {
+                guard id != localPlayerID, state.hasNetworkPosition else { return nil }
+                return CGPoint(x: state.position.x, y: state.position.y)
+            }()
+
+            controller.applyMovement(
+                deltaTime: deltaTime,
+                moveX: state.moveX,
+                isGrounded: state.isGrounded,
+                targetPosition: targetPosition
+            )
+
+            if gameplayManager.isJumpRequested(for: id) {
+                controller.applyJump()
+                gameplayManager.resetJumpRequest(for: id)
+            }
+        }
     }
     
     private func updateRemotePlayerScreenPosition() {
@@ -292,6 +312,37 @@ final class GameScene: SKScene {
         return UUID(uuidString: uuidString)
     }
 
+    private func syncLocalPlayerPositionToGameState(
+        gameplayManager: GameplayManager,
+        deltaTime: TimeInterval,
+        force: Bool = false
+    ) {
+        guard let localNode = characterControllers[localPlayerID]?.playerNode else { return }
+        let current = CharacterPosition(
+            x: Double(localNode.position.x),
+            y: Double(localNode.position.y)
+        )
+
+        if force {
+            gameplayManager.updatePosition(current, for: localPlayerID)
+            lastSyncedLocalPosition = current
+            localPositionSyncAccumulator = 0
+            return
+        }
+
+        localPositionSyncAccumulator += deltaTime
+        guard localPositionSyncAccumulator >= localPositionSyncInterval else { return }
+        localPositionSyncAccumulator = 0
+
+        if let last = lastSyncedLocalPosition {
+            let movedDistance = hypot(current.x - last.x, current.y - last.y)
+            guard movedDistance >= localPositionSyncMinDistance else { return }
+        }
+
+        gameplayManager.updatePosition(current, for: localPlayerID)
+        lastSyncedLocalPosition = current
+    }
+
 }
 
 extension GameScene: SKPhysicsContactDelegate {
@@ -336,7 +387,7 @@ extension GameScene: SKPhysicsContactDelegate {
                     if let idx = platformController?.lastSafePlatformIndex,
                        let safe = platformController?.lastSafePosition {
                         gameplayManager?.updateLastSafePosition(
-                            RespawnPosition(x: Double(safe.x),
+                            CharacterPosition(x: Double(safe.x),
                                             y: Double(safe.y)),
                             for: playerID
                         )

--- a/iOS/Modules/GameEngineCore/Sources/Physics/PhysicsConstants.swift
+++ b/iOS/Modules/GameEngineCore/Sources/Physics/PhysicsConstants.swift
@@ -32,4 +32,12 @@ public enum PhysicsConstants {
     public static let linearDamping: CGFloat = 0.5
     public static let friction: CGFloat = 1.0
     public static let restitution: CGFloat = 0.0
+
+    // 원격 위치 보정
+    public static let networkSyncDeadZone: CGFloat = 2.0
+    public static let networkSyncMinCorrectionGain: CGFloat = 4.0
+    public static let networkSyncMaxCorrectionGain: CGFloat = 14.0
+    public static let networkSyncGainDistance: CGFloat = 200.0
+    public static let networkSyncMaxCorrectionSpeed: CGFloat = 900.0
+    public static let networkSyncEmergencySnapDistance: CGFloat = 1200.0
 }

--- a/iOS/Modules/GameEngineCore/Sources/Physics/PhysicsCore.swift
+++ b/iOS/Modules/GameEngineCore/Sources/Physics/PhysicsCore.swift
@@ -24,12 +24,22 @@ public final class PhysicsCore {
     }
 
     // 매 프레임 호출: State -> Velocity 적용
-    public func applyState(deltaTime: TimeInterval, moveX: Double, isGrounded: Bool) {
+    public func applyState(
+        deltaTime: TimeInterval,
+        moveX: Double,
+        isGrounded: Bool,
+        targetPosition: CGPoint? = nil
+    ) {
         // X축 이동
         applyMovement(moveX: moveX, isGrounded: isGrounded)
 
         // Y축 중력 보정 (Apex Control)
         applyGravityCorrection(deltaTime: deltaTime, isGrounded: isGrounded)
+
+        // 원격 위치 동기화 보정(속도 기반)
+        if let targetPosition {
+            applyNetworkPositionCorrection(targetPosition, deltaTime: deltaTime)
+        }
     }
 
     // 즉발적인 점프 힘 적용
@@ -105,5 +115,50 @@ public final class PhysicsCore {
 
         let additionalGravity = PhysicsConstants.gravityDY * (multiplier - 1.0) * CGFloat(deltaTime)
         body.velocity = CGVector(dx: body.velocity.dx, dy: velocityY + additionalGravity)
+    }
+
+    private func applyNetworkPositionCorrection(_ targetPosition: CGPoint, deltaTime: TimeInterval) {
+        guard let body,
+              let node = body.node,
+              deltaTime > 0 else { return }
+
+        let current = node.position
+        let dx = targetPosition.x - current.x
+        let dy = targetPosition.y - current.y
+        let distance = hypot(dx, dy)
+
+        if distance <= PhysicsConstants.networkSyncDeadZone {
+            return
+        }
+
+        // 비정상적으로 크게 벌어진 경우에만 안전 스냅
+        if distance >= PhysicsConstants.networkSyncEmergencySnapDistance {
+            node.position = targetPosition
+            body.velocity = .zero
+            return
+        }
+
+        let gainT = min(max(distance / PhysicsConstants.networkSyncGainDistance, 0), 1)
+        let gain = CGFloat.lerp(
+            start: PhysicsConstants.networkSyncMinCorrectionGain,
+            end: PhysicsConstants.networkSyncMaxCorrectionGain,
+            t: gainT
+        )
+
+        let desiredVx = dx * gain
+        let desiredVy = dy * gain
+        let maxSpeed = PhysicsConstants.networkSyncMaxCorrectionSpeed
+
+        let correctionVx = clamp(desiredVx, min: -maxSpeed, max: maxSpeed)
+        let correctionVy = clamp(desiredVy, min: -maxSpeed, max: maxSpeed)
+
+        body.velocity = CGVector(
+            dx: body.velocity.dx + correctionVx * CGFloat(deltaTime),
+            dy: body.velocity.dy + correctionVy * CGFloat(deltaTime)
+        )
+    }
+
+    private func clamp(_ value: CGFloat, min minValue: CGFloat, max maxValue: CGFloat) -> CGFloat {
+        min(maxValue, max(minValue, value))
     }
 }

--- a/iOS/Modules/Games/Sources/GameplayManager.swift
+++ b/iOS/Modules/Games/Sources/GameplayManager.swift
@@ -59,10 +59,10 @@ public final class GameplayManager {
     public var onDidUpdate: ((TimeInterval) -> Void)?
     
     @ObservationIgnored
-    public var onRespawnConfirmed: ((UUID, RespawnReason, RespawnPosition) -> Void)?
+    public var onRespawnConfirmed: ((UUID, RespawnReason, CharacterPosition) -> Void)?
 
     @ObservationIgnored
-    private var pendingRespawnPositionByPlayerID: [UUID: RespawnPosition] = [:]
+    private var pendingRespawnPositionByPlayerID: [UUID: CharacterPosition] = [:]
     
     // 조절값
     private let maxJumpCount = 2
@@ -177,6 +177,10 @@ extension GameplayManager {
     public func updateMoveX(_ moveX: Double, for playerID: UUID) {
         state.setMoveX(moveX, for: playerID)
     }
+
+    public func updatePosition(_ position: CharacterPosition, for playerID: UUID) {
+        state.setPosition(position, for: playerID)
+    }
     
     private func tryJump(for playerID: UUID) {
         // 로컬 점프 검증은 로컬 플레이어만 수행
@@ -275,11 +279,11 @@ extension GameplayManager {
     
     // MARK: Remote
     
-    public func updateLastSafePosition(_ pos: RespawnPosition, for playerID: UUID) {
+    public func updateLastSafePosition(_ pos: CharacterPosition, for playerID: UUID) {
         state.setLastSafePosition(pos, for: playerID)
     }
     
-    public func applyRespawnRequested(_ reason: RespawnReason, position: RespawnPosition, for playerID: UUID) {
+    public func applyRespawnRequested(_ reason: RespawnReason, position: CharacterPosition, for playerID: UUID) {
         guard playerID != localPlayerID else { return }
         guard state.isRespawning(playerID) == false else { return }
 
@@ -287,7 +291,7 @@ extension GameplayManager {
         state.setIsRespawning(true, reason, for: playerID)
     }
     
-    public func consumeRespawnPosition(for playerID: UUID) -> RespawnPosition? {
+    public func consumeRespawnPosition(for playerID: UUID) -> CharacterPosition? {
         pendingRespawnPositionByPlayerID.removeValue(forKey: playerID)
     }
 }

--- a/iOS/Modules/Games/Sources/Model/CharacterState.swift
+++ b/iOS/Modules/Games/Sources/Model/CharacterState.swift
@@ -7,18 +7,35 @@
 
 import Foundation
 
+public struct CharacterPosition: Sendable, Codable, Equatable {
+    public var x: Double
+    public var y: Double
+    public static let zero = CharacterPosition(x: 0, y: 0)
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
 public struct CharacterState: Equatable, Sendable {
     public var moveX: Double = 0 // 좌우 이동 속도 비율 (-1.0 ~ 1.0)
+    public var position: CharacterPosition = .zero
+    public var hasNetworkPosition: Bool = false
     public var jumpCount: Int = 0
     public var isGrounded: Bool = false
     public var respawn: RespawnState
 
     public init(
         moveX: Double = 0,
+        position: CharacterPosition = .zero,
+        hasNetworkPosition: Bool = false,
         jumpCount: Int = 0,
         isGrounded: Bool = true
     ) {
         self.moveX = moveX
+        self.position = position
+        self.hasNetworkPosition = hasNetworkPosition
         self.jumpCount = jumpCount
         self.isGrounded = isGrounded
         self.respawn = RespawnState()

--- a/iOS/Modules/Games/Sources/Model/GameState.swift
+++ b/iOS/Modules/Games/Sources/Model/GameState.swift
@@ -37,6 +37,14 @@ public struct GameState: Equatable, Sendable {
         characters[id, default: .init()].moveX = moveX
     }
 
+    public mutating func setPosition(_ position: CharacterPosition, for id: UUID) {
+        ensurePlayer(id)
+        guard var character = characters[id] else { return }
+        character.position = position
+        character.hasNetworkPosition = true
+        characters[id] = character
+    }
+
     public mutating func setGrounded(_ grounded: Bool, for id: UUID) {
         characters[id, default: .init()].isGrounded = grounded
     }
@@ -75,7 +83,7 @@ public struct GameState: Equatable, Sendable {
         return reason
     }
     
-    mutating func setLastSafePosition(_ pos: RespawnPosition, for playerID: UUID) {
+    mutating func setLastSafePosition(_ pos: CharacterPosition, for playerID: UUID) {
         guard var character = characters[playerID] else { return }
         character.respawn.lastSafePosition = pos
         characters[playerID] = character

--- a/iOS/Modules/Games/Sources/Model/RespawnState.swift
+++ b/iOS/Modules/Games/Sources/Model/RespawnState.swift
@@ -5,24 +5,13 @@
 //  Created by sungkug_apple_developer_ac on 1/12/26.
 //
 
-public struct RespawnPosition: Sendable, Codable, Equatable {
-    public var x: Double
-    public var y: Double
-    public static let zero = RespawnPosition(x: 0, y: 0)
-
-    public init(x: Double, y: Double) {
-        self.x = x
-        self.y = y
-    }
-}
-
 public enum RespawnReason: Sendable {
     case fell
     case hitMonster
 }
 
 public struct RespawnState: Equatable, Sendable {
-    public var lastSafePosition: RespawnPosition = .zero
+    public var lastSafePosition: CharacterPosition = .zero
     public var isRespawning: Bool = false
     public var pendingReason: RespawnReason? = nil
     

--- a/iOS/Modules/NetworkKit/Sources/DTO/NetworkGameInputDTO.swift
+++ b/iOS/Modules/NetworkKit/Sources/DTO/NetworkGameInputDTO.swift
@@ -18,23 +18,49 @@ public struct NetworkGameInputDTO: Codable, Sendable {
 
     public var kind: Kind
     public var x: Double?
+    public var positionX: Double?
+    public var positionY: Double?
+    public var jumpSeq: Int?
 
     // respawn
     public var reason: Int?
     public var respawnX: Double?
     public var respawnY: Double?
 
-    public init(kind: Kind, x: Double? = nil) {
+    public init(
+        kind: Kind,
+        x: Double? = nil,
+        positionX: Double? = nil,
+        positionY: Double? = nil
+    ) {
         self.kind = kind
         self.x = x
+        self.positionX = positionX
+        self.positionY = positionY
     }
 
-    public static func horizontal(_ x: Double) -> Self {
-        .init(kind: .horizontal, x: x)
+    public static func horizontal(_ x: Double, positionX: Double? = nil, positionY: Double? = nil) -> Self {
+        .init(kind: .horizontal, x: x, positionX: positionX, positionY: positionY)
     }
 
     public static var jumpTriggered: Self {
         .init(kind: .jumpTriggered, x: nil)
+    }
+
+    public static func jumpTriggered(
+        moveX: Double,
+        positionX: Double,
+        positionY: Double,
+        jumpSeq: Int
+    ) -> Self {
+        var dto = Self(
+            kind: .jumpTriggered,
+            x: moveX,
+            positionX: positionX,
+            positionY: positionY
+        )
+        dto.jumpSeq = jumpSeq
+        return dto
     }
     
     public static func respawnRequested(reason: Int, x: Double, y: Double) -> Self {

--- a/iOS/Modules/NetworkKit/Sources/WebSocket/WebSocketService.swift
+++ b/iOS/Modules/NetworkKit/Sources/WebSocket/WebSocketService.swift
@@ -67,6 +67,7 @@ public final class WebSocketService: NSObject {
 
             webSocketTask?.send(.string(text)) { [weak self] error in
                 if let error {
+                    print(error)
                     self?.handleError(error)
                 }
             }


### PR DESCRIPTION
[DEV-000]

## 요약
2인 모드에서 상대 플레이어의 위치가 점점 어긋나는 문제를 완화하기 위해
위치 스냅샷 기반 보정 로직을 구현했습니다.

기존에는 입력 기반 동기화만 사용하여 네트워크 지연 상황에서 위치 드리프트가 발생했지만, 입력 데이터에 현재 위치 스냅샷을 함께 전달하고 원격 플레이어에 보정 로직을 적용하여 위치 동기화 안정성을 개선했습니다.

### 작업 목록
- [x] 네트워크 입력 DTO에 위치 스냅샷 필드 추가
- [x] 점프 이벤트에 위치 스냅샷 전달
- [x] 원격 캐릭터 위치 보정 로직 구현
- [x] 로컬 캐릭터 위치 GameState 동기화
- [x] 네트워크 전송 조건에 위치 변화 추가

## 작업 내용
### AS-IS

입력 값(moveX, jump 등)만 네트워크로 전달

네트워크 지연 시 원격 플레이어 위치 드리프트 발생

위치 차이가 커질 경우 순간 이동처럼 보이는 문제 발생

### TO-BE

네트워크 입력에 현재 위치 스냅샷(positionX, positionY) 추가

점프 이벤트 발생 시 위치 정보와 함께 전달

원격 캐릭터에 속도 기반 위치 보정 로직 적용

일정 거리 이상 차이 발생 시 긴급 스냅(emergency snap) 적용


## 참고 사항
위치 보정은 DeadZone / Gain 기반 보정 / Emergency Snap 단계로 동작하도록 구현했습니다.

로컬 플레이어의 위치를 일정 주기로 GameState에 반영하여 네트워크 동기화 기준으로 사용합니다.

위치 드리프트 문제 완화를 목표로 한 기능이며, 추후 추가적인 네트워크 동기화 개선이 필요할 수 있습니다.

refs DEV-74
